### PR TITLE
fix zombienet toml

### DIFF
--- a/xcm-playground.toml
+++ b/xcm-playground.toml
@@ -16,9 +16,14 @@ default_command = "./bin/polkadot"
   validator = true
   extra_args = [ "-lparachain=debug" ]
 
+  [[relaychain.nodes]]
+  name = "charlie"
+  validator = true
+  extra_args = [ "-lparachain=debug" ]
+
 [[parachains]]
 id = 1000
-addToGenesis = true
+add_to_genesis = true
 cumulus_based = true
 chain = "statemine-local"
 
@@ -36,7 +41,7 @@ chain = "statemine-local"
 
 [[parachains]]
 id = 2000
-addToGenesis = true
+add_to_genesis = true
 cumulus_based = true
 
   [[parachains.collators]]
@@ -53,9 +58,8 @@ cumulus_based = true
 
 [[parachains]]
 id = 3000
-addToGenesis = true
+add_to_genesis = true
 cumulus_based = true
-chain = ""
 
   [[parachains.collators]]
   name = "collator01"


### PR DESCRIPTION
On https://github.com/paritytech/trappist/pull/63 I reduced the number of relay validators to save up resources.

That caused parachain 3000 to not be able to produce blocks anymore. It turns out that we need at least three relay validators so that all three parachains can produce blocks.

This PR fixes this by adding a new relay validator (`charlie`).

It also fixes the `addToGenesis` fields to camel case form `add_to_genesis`.