### PR TITLE
Minor CI improvements

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,16 +23,21 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set-Up
-        run: sudo apt install -y git clang curl libssl-dev llvm libudev-dev cmake protobuf-compiler
+        run: sudo apt update && sudo apt install -y git clang curl libssl-dev llvm libudev-dev cmake protobuf-compiler
 
-      - name: Install Rustup
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          source ~/.cargo/env
-          rustup default stable
-          rustup update nightly
-          rustup update stable
-          rustup target add wasm32-unknown-unknown --toolchain nightly
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - name: Install Nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          target: wasm32-unknown-unknown
 
       - name: Check Build
         run: |


### PR DESCRIPTION
- use [actions-rs](https://github.com/actions-rs/toolchain) to simplify Rust toolchain installation, inline with other Parity repositories
- allow local workflow runs via [act](https://github.com/nektos/act) to easily validate before pushing