### PR TITLE
test: update expected polkadotXcm.attempted event value (with threshold)

### DIFF
--- a/integration-tests/asset-registry/0_reserve_transfer.yml
+++ b/integration-tests/asset-registry/0_reserve_transfer.yml
@@ -226,7 +226,8 @@ tests:
                         attributes:
                           - type: XcmV2TraitsOutcome
                             xcmOutcome: Complete
-                            value: 1,000,000,000
+                            threshold: [10, 10]
+                            value: 654,608,000
                       - name: assets.Transferred
                         attributes:
                           - type: AccountId32


### PR DESCRIPTION
The reserve-transfer integration test is failing after updating to 0.9.30 with the following error:

`Expected Attribute: 'XcmV2TraitsOutcome' : "1,000,000,000" | Received Attribute: 'XcmV2TraitsOutcome' : "654,608,000" `

https://github.com/paritytech/cumulus/commit/27d05a38e151794c30880592d5bcc3b2aa58a95d#diff-ba1aa16da44c3c45953fbb3ae34a4a3ed4d6d898f1bfe16b32d0fd91daf0f80b shows a downward adjustment of the expected weight in the statemine integration test, along with threshold, so this PR simply applys the same fix.