### PR TITLE
Custom Matcher (ConvertedRegisteredAssetId) for ReservedFungiblesTransactor

### DIFF
--- a/integration-tests/asset-registry/0_reserve_transfer.yml
+++ b/integration-tests/asset-registry/0_reserve_transfer.yml
@@ -227,7 +227,7 @@ tests:
                           - type: XcmV2TraitsOutcome
                             xcmOutcome: Complete
                             threshold: [10, 10]
-                            value: 654,608,000
+                            value: 1,000,000,000
                       - name: assets.Transferred
                         attributes:
                           - type: AccountId32

--- a/primitives/xcm/src/lib.rs
+++ b/primitives/xcm/src/lib.rs
@@ -1,7 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use sp_std::{borrow::Borrow, marker::PhantomData};
-use xcm::latest::MultiLocation;
+use xcm::latest::{AssetId::Concrete, Fungibility::Fungible, MultiAsset, MultiLocation};
+use xcm_executor::traits::{Convert, Error as MatchError, MatchesFungibles};
 
 pub struct AsAssetMultiLocation<AssetId, AssetIdInfoGetter>(
 	PhantomData<(AssetId, AssetIdInfoGetter)>,
@@ -24,4 +25,27 @@ where
 pub trait AssetMultiLocationGetter<AssetId> {
 	fn get_asset_multi_location(asset_id: AssetId) -> Option<MultiLocation>;
 	fn get_asset_id(asset_multi_location: MultiLocation) -> Option<AssetId>;
+}
+
+pub struct ConvertedRegisteredAssetId<AssetId, Balance, ConvertAssetId, ConvertBalance>(
+	PhantomData<(AssetId, Balance, ConvertAssetId, ConvertBalance)>,
+);
+impl<
+		AssetId: Clone,
+		Balance: Clone,
+		ConvertAssetId: Convert<MultiLocation, AssetId>,
+		ConvertBalance: Convert<u128, Balance>,
+	> MatchesFungibles<AssetId, Balance>
+	for ConvertedRegisteredAssetId<AssetId, Balance, ConvertAssetId, ConvertBalance>
+{
+	fn matches_fungibles(a: &MultiAsset) -> Result<(AssetId, Balance), MatchError> {
+		let (amount, id) = match (&a.fun, &a.id) {
+			(Fungible(ref amount), Concrete(ref id)) => (amount, id),
+			_ => return Err(MatchError::AssetNotFound),
+		};
+		let what = ConvertAssetId::convert_ref(id).map_err(|_| MatchError::AssetNotFound)?;
+		let amount = ConvertBalance::convert_ref(amount)
+			.map_err(|_| MatchError::AmountToBalanceConversionFailed)?;
+		Ok((what, amount))
+	}
 }

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -32,7 +32,7 @@ use parachains_common::{
 	AssetId,
 };
 use xcm_executor::traits::{FilterAssetLocation, JustTry};
-use xcm_primitives::AsAssetMultiLocation;
+use xcm_primitives::{AsAssetMultiLocation, ConvertedRegisteredAssetId};
 
 // use super::xcm_primitives::{AbsoluteReserveProvider, MultiNativeAsset};
 use pallet_xcm::{EnsureXcm, IsMajorityOfBody, XcmPassthrough};
@@ -121,8 +121,9 @@ pub type LocalFungiblesTransactor = FungiblesAdapter<
 pub type ReservedFungiblesTransactor = FungiblesAdapter<
 	// Use this fungibles implementation:
 	Assets,
-	// Use this currency when it is a fungible asset matching the given location or name:
-	ConvertedConcreteAssetId<
+	// Use this currency when it is a registered fungible asset matching the given location or name
+	// Assets not found in AssetRegistry will not be used
+	ConvertedRegisteredAssetId<
 		AssetId,
 		Balance,
 		AsAssetMultiLocation<AssetId, AssetRegistry>,


### PR DESCRIPTION
close #51 

`ConvertedRegisteredAssetId` is a custom implementation of the `MatchesFungibles` trait that allows `ReservedFungiblesTransactor` to coexist with `LocalFungiblesTransactor` without having its execution priority block the second Transactor from ever being triggered.

Whenever `ConvertedRegisteredAssetId` can't find the Asset in `AssetRegistry` (`what = ConvertAssetId::convert_ref(id)`), a `MatchError::AssetNotFound` is thrown (instead of `MatchError::AssetIdConversionFailed`).

That allows the [`TransactAsset` trait implementation for Tuple](https://github.com/paritytech/polkadot/blob/3711c6f9b2a30ab6cc888917ad0bbfa64266d41b/xcm/xcm-executor/src/traits/transact_asset.rs#L117) to simply bypass the `ReservedFungiblesTransactor` without halting the XCM execution with a `FailedToTransactAsset("AssetIdConversionFailed")` error.

Integration tests that assert the correctness of this solution can be found on the [`bar/52-asset-trap`](https://github.com/paritytech/trappist/tree/bar/52-asset-trap/integration-tests/asset-trap) branch.