### PR TITLE
remove test asset from GenesisConfig

### DIFF
--- a/node/service/src/chain_spec/trappist.rs
+++ b/node/service/src/chain_spec/trappist.rs
@@ -223,11 +223,7 @@ fn testnet_genesis(
 			// Assign network admin rights.
 			key: Some(root_key),
 		},
-		assets: AssetsConfig {
-			assets: vec![],
-			accounts: vec![],
-			metadata: vec![],
-		},
+		assets: AssetsConfig { assets: vec![], accounts: vec![], metadata: vec![] },
 		council: CouncilConfig {
 			members: invulnerables.iter().map(|x| x.0.clone()).collect::<Vec<_>>(),
 			phantom: Default::default(),


### PR DESCRIPTION
While working on PR #63 I introduced an [`AssetsConfig` into the `GenesisConfig` of `testnet_genesis`](https://github.com/paritytech/trappist/blob/b8d0c35092190f40fd53baeed232d62af4b44d28/node/src/chain_spec.rs#L228).

This introduced a `txUSD` to pre-exist on Genesis.
That can be confusing for newcomers following tutorials that will instruct them to manually create a `txUSD` asset on Trappist.

This PR removes it.