### PR TITLE
ci: cache build artifacts

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04
     env:
-      NIGHTLY: nightly-2022-11-02
+      NIGHTLY: nightly-2022-11-02 # Fix version to prevent cache misses with nightly changes
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -37,15 +37,30 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ env.NIGHTLY }} # Specific version used otherwise potentially new cache each day due to nightly changes
+          toolchain: ${{ env.NIGHTLY }}
           override: true
           target: wasm32-unknown-unknown
           components: rustfmt
 
-      - name: Cache Build artefacts
-        uses: Swatinem/rust-cache@v2
+      # Fail fast: check formatting first as it doesn't require compilation
+      - name: Check formatting
+        uses: actions-rs/cargo@v1
         with:
-          shared-key: "checks-v2"
+          toolchain: ${{ env.NIGHTLY }}
+          command: fmt
+          args: --all --check
+
+      - name: Cache Build artefacts
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Check Build Trappist Runtime
         run: |
@@ -63,11 +78,4 @@ jobs:
       - name: Check Build for Benchmarking Base Runtime
         run: >
           pushd node &&
-          cargo check --features=runtime-benchmarks,with-base-runtime --release 
-
-      - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          toolchain: ${{ env.NIGHTLY }}
-          command: fmt
-          args: --all --check
+          cargo check --features=runtime-benchmarks,with-base-runtime --release


### PR DESCRIPTION
- replaced `rust-cache` action with standard `actions` action as it was causing issues
- check formatting first as it doesn't require compilation (fail fast)

Fastest build with cache unfortunately only around 18m due to a few crates still being rebuilt on subsequent runs, but half the time of the initial build without cache. Tried separating benchmarks into separate jobs as doing so locally resulted in no recompilations across the four checks on subsequent runs, so perhaps issue lies with way in which some artifacts are compressed and restored, resulting in recompilation.