### PR TITLE
Build trappist runtime by default

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Check Build Base Runtime
         run: |
-          SKIP_WASM_BUILD=1 cargo check --release --no-defaults-features --features with-base-runtime
+          SKIP_WASM_BUILD=1 cargo check --release --no-default-features --features with-base-runtime
 
       - name: Check Build for Benchmarking Trappist Runtime
         run: >
@@ -78,4 +78,4 @@ jobs:
       - name: Check Build for Benchmarking Base Runtime
         run: >
           pushd node &&
-          cargo check --no-defaults-features --features=runtime-benchmarks,with-base-runtime --release
+          cargo check --no-default-features --features=runtime-benchmarks,with-base-runtime --release

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Check Build Base Runtime
         run: |
-          SKIP_WASM_BUILD=1 cargo check --release --features with-base-runtime
+          SKIP_WASM_BUILD=1 cargo check --release --no-defaults-features --features with-base-runtime
 
       - name: Check Build for Benchmarking Trappist Runtime
         run: >
@@ -78,4 +78,4 @@ jobs:
       - name: Check Build for Benchmarking Base Runtime
         run: >
           pushd node &&
-          cargo check --features=runtime-benchmarks,with-base-runtime --release
+          cargo check --no-defaults-features --features=runtime-benchmarks,with-base-runtime --release

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -33,7 +33,7 @@ nix = "0.23"
 tempfile = "3.2.0"
 
 [features]
-default = []
+default = ["with-trappist-runtime"]
 runtime-benchmarks = [
     "trappist-cli/runtime-benchmarks"
 ]


### PR DESCRIPTION
Build failing when running `cargo build --release` is counter-intuitive.
Build the trappist-runtime by default (node's default feature).