### PR TITLE
ci: fix simulate workflow artifact caching

### DIFF
--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -53,6 +53,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
+            xcm-simulator/target/
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-test
 
@@ -73,7 +74,7 @@ jobs:
         uses: dorny/test-reporter@v1
         if: success() || failure()    # run this step even if previous step failed
         with:
-          name: simulate
+          name: results
           path: target/nextest/ci/junit.xml
           reporter: jest-junit
           working-directory: 'xcm-simulator'

--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -4,7 +4,7 @@ name: XCM Simulator
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master, xcm-simulator ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
Caching action doesn't seem to take `working-directory` set a job level into account so manually added it to the caching step.
Also improved name of test results output.