### PR TITLE
fix: add local asset transactor type definition

### DIFF
--- a/xcm-simulator/src/lib.rs
+++ b/xcm-simulator/src/lib.rs
@@ -684,4 +684,32 @@ mod tests {
 			})),
 		)
 	}
+
+	#[test]
+	fn event_collection_works() {
+		init_tracing();
+
+		MockNet::reset();
+
+		const AMOUNT: u128 = trappist::EXISTENTIAL_DEPOSIT * 10;
+		const MAX_WEIGHT: u128 = 1_000_000_000;
+
+		Trappist::execute_with(|| {
+			assert_ok!(trappist::PolkadotXcm::execute(
+				trappist::RuntimeOrigin::signed(ALICE),
+				Box::new(VersionedXcm::from(Xcm(vec![WithdrawAsset(((0, Here), AMOUNT).into())]))),
+				Weight::from_ref_time(MAX_WEIGHT as u64)
+			));
+			assert_eq!(3, trappist::System::events().len());
+		});
+
+		Base::execute_with(|| {
+			assert_ok!(base::PolkadotXcm::execute(
+				base::RuntimeOrigin::signed(ALICE),
+				Box::new(VersionedXcm::from(Xcm(vec![WithdrawAsset(((0, Here), AMOUNT).into())]))),
+				Weight::from_ref_time(MAX_WEIGHT as u64)
+			));
+			assert_eq!(3, trappist::System::events().len());
+		});
+	}
 }

--- a/xcm-simulator/src/parachains/base.rs
+++ b/xcm-simulator/src/parachains/base.rs
@@ -22,9 +22,8 @@ use base_runtime::{
 		fee::WeightToFee,
 	},
 	xcm_config::{
-		AssetTransactors, Barrier, CollatorSelectionUpdateOrigin, LocationToAccountId,
-		MaxInstructions, RelayLocation, RelayNetwork, Reserves, SelfReserve, UnitWeightCost,
-		XUsdPerSecond,
+		Barrier, CollatorSelectionUpdateOrigin, LocationToAccountId, MaxInstructions,
+		RelayLocation, RelayNetwork, Reserves, SelfReserve, UnitWeightCost, XUsdPerSecond,
 	},
 	BlockNumber, DealWithFees, Hash, Header, Index, Period, PotId, RuntimeBlockLength,
 	RuntimeBlockWeights, Session, UnitBody, Version,
@@ -40,12 +39,13 @@ use polkadot_runtime_common::BlockHashCount;
 use sp_core::{ConstU128, ConstU16, ConstU32};
 use sp_runtime::traits::{AccountIdLookup, BlakeTwo256};
 use sp_std::prelude::*;
+use trappist_runtime::xcm_config::{LocalFungiblesTransactor, ReservedFungiblesTransactor};
 pub use trappist_runtime::{AccountId, AssetId, Balance};
 use xcm::latest::prelude::*;
 use xcm_builder::{
-	EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, LocationInverter, ParentAsSuperuser,
-	RelayChainAsNative, SiblingParachainAsNative, SignedAccountId32AsNative, SignedToAccountId32,
-	SovereignSignedViaLocation, UsingComponents,
+	CurrencyAdapter, EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, IsConcrete,
+	LocationInverter, ParentAsSuperuser, RelayChainAsNative, SiblingParachainAsNative,
+	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, UsingComponents,
 };
 use xcm_executor::{Config, XcmExecutor};
 
@@ -162,6 +162,10 @@ parameter_types! {
 	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
 }
 
+pub type LocalAssetTransactor =
+	CurrencyAdapter<Balances, IsConcrete<SelfReserve>, LocationToAccountId, AccountId, ()>;
+pub type AssetTransactors =
+	(LocalAssetTransactor, ReservedFungiblesTransactor, LocalFungiblesTransactor);
 pub type XcmOriginToTransactDispatchOrigin = (
 	SovereignSignedViaLocation<LocationToAccountId, RuntimeOrigin>,
 	RelayChainAsNative<RelayChainOrigin, RuntimeOrigin>,

--- a/xcm-simulator/src/parachains/trappist.rs
+++ b/xcm-simulator/src/parachains/trappist.rs
@@ -27,25 +27,25 @@ use polkadot_runtime_common::BlockHashCount;
 use sp_core::{ConstU128, ConstU16, ConstU32};
 use sp_runtime::traits::{AccountIdLookup, BlakeTwo256};
 use sp_std::prelude::*;
+pub use trappist_runtime::{constants::currency::EXISTENTIAL_DEPOSIT, AccountId, AssetId, Balance};
 use trappist_runtime::{
 	constants::{
-		currency::{CENTS, EXISTENTIAL_DEPOSIT, UNITS},
+		currency::{CENTS, UNITS},
 		fee::WeightToFee,
 	},
 	xcm_config::{
-		AssetTransactors, Barrier, CollatorSelectionUpdateOrigin, LocationToAccountId,
-		MaxInstructions, RelayLocation, RelayNetwork, Reserves, SelfReserve, UnitWeightCost,
-		XUsdPerSecond,
+		Barrier, CollatorSelectionUpdateOrigin, LocalFungiblesTransactor, LocationToAccountId,
+		MaxInstructions, RelayLocation, RelayNetwork, ReservedFungiblesTransactor, Reserves,
+		SelfReserve, UnitWeightCost, XUsdPerSecond,
 	},
 	BlockNumber, DealWithFees, Hash, Header, Index, Period, PotId, RuntimeBlockLength,
 	RuntimeBlockWeights, Session, UnitBody, Version,
 };
-pub use trappist_runtime::{AccountId, AssetId, Balance};
 use xcm::latest::prelude::*;
 use xcm_builder::{
-	EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, LocationInverter, ParentAsSuperuser,
-	RelayChainAsNative, SiblingParachainAsNative, SignedAccountId32AsNative, SignedToAccountId32,
-	SovereignSignedViaLocation, UsingComponents,
+	CurrencyAdapter, EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, IsConcrete,
+	LocationInverter, ParentAsSuperuser, RelayChainAsNative, SiblingParachainAsNative,
+	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, UsingComponents,
 };
 use xcm_executor::{Config, XcmExecutor};
 
@@ -169,6 +169,10 @@ parameter_types! {
 	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
 }
 
+pub type LocalAssetTransactor =
+	CurrencyAdapter<Balances, IsConcrete<SelfReserve>, LocationToAccountId, AccountId, ()>;
+pub type AssetTransactors =
+	(LocalAssetTransactor, ReservedFungiblesTransactor, LocalFungiblesTransactor);
 pub type XcmOriginToTransactDispatchOrigin = (
 	SovereignSignedViaLocation<LocationToAccountId, RuntimeOrigin>,
 	RelayChainAsNative<RelayChainOrigin, RuntimeOrigin>,


### PR DESCRIPTION
Re-using `LocalAssetTransactor` from main runtimes was causing incorrect `Balances` type usage, resulting in stored events which could not be decoded back to mock runtime events:

`ERROR runtime::storage: Corrupted state at ..`