### PR TITLE
fix(base): add local asset transactor type definition

### DIFF
--- a/xcm-simulator/src/lib.rs
+++ b/xcm-simulator/src/lib.rs
@@ -210,13 +210,12 @@ mod tests {
 	use crate::relay_chain::mock_paras_sudo_wrapper;
 	use codec::Encode;
 	use frame_support::{
-		assert_ok,
+		assert_ok, log,
 		pallet_prelude::{DispatchResult, DispatchResultWithPostInfo},
 		traits::PalletInfoAccess,
 	};
 	use std::sync::Once;
 	use thousands::Separable;
-	use tracing::trace;
 	use xcm::prelude::*;
 	use xcm_simulator::{TestExt, Weight};
 
@@ -226,7 +225,7 @@ mod tests {
 			// Add test tracing (from sp_tracing::init_for_tests()) but filtering for xcm logs only
 			let _ = tracing_subscriber::fmt()
 				.with_max_level(tracing::Level::TRACE)
-				.with_env_filter("xcm=trace,xcm_simulator_trappist=trace") // Comment out this line to see all traces
+				.with_env_filter("xcm=trace,system::events=trace") // Comment out this line to see all traces
 				.with_test_writer()
 				.init();
 		});
@@ -590,6 +589,36 @@ mod tests {
 		});
 	}
 
+	#[test]
+	fn event_collection_works() {
+		init_tracing();
+
+		MockNet::reset();
+
+		const AMOUNT: u128 = trappist::EXISTENTIAL_DEPOSIT * 10;
+		const MAX_WEIGHT: u128 = 1_000_000_000;
+
+		Trappist::execute_with(|| {
+			assert_ok!(trappist::PolkadotXcm::execute(
+				trappist::RuntimeOrigin::signed(ALICE),
+				Box::new(VersionedXcm::from(Xcm(vec![WithdrawAsset(((0, Here), AMOUNT).into())]))),
+				Weight::from_ref_time(MAX_WEIGHT as u64)
+			));
+			output_events::<trappist::Runtime>();
+			assert_eq!(3, trappist::System::events().len());
+		});
+
+		Base::execute_with(|| {
+			assert_ok!(base::PolkadotXcm::execute(
+				base::RuntimeOrigin::signed(ALICE),
+				Box::new(VersionedXcm::from(Xcm(vec![WithdrawAsset(((0, Here), AMOUNT).into())]))),
+				Weight::from_ref_time(MAX_WEIGHT as u64)
+			));
+			output_events::<base::Runtime>();
+			assert_eq!(1, trappist::System::events().len());
+		});
+	}
+
 	fn assert_balance(actual: u128, expected: u128, fees: u128) {
 		assert!(
 			actual >= (expected - fees) && actual <= expected,
@@ -646,10 +675,11 @@ mod tests {
 
 	// Helper for outputting events
 	fn output_events<Runtime: frame_system::Config>() {
+		const TARGET: &str = "system::events";
 		let events = frame_system::Pallet::<Runtime>::events();
-		trace!("{} events", events.len());
+		log::trace!(target: TARGET, "{} events", events.len());
 		for event in events {
-			trace!("{:?}", event)
+			log::trace!(target: TARGET, "{:?}", event)
 		}
 	}
 
@@ -693,35 +723,5 @@ mod tests {
 					.into(),
 			})),
 		)
-	}
-
-	#[test]
-	fn event_collection_works() {
-		init_tracing();
-
-		MockNet::reset();
-
-		const AMOUNT: u128 = trappist::EXISTENTIAL_DEPOSIT * 10;
-		const MAX_WEIGHT: u128 = 1_000_000_000;
-
-		Trappist::execute_with(|| {
-			assert_ok!(trappist::PolkadotXcm::execute(
-				trappist::RuntimeOrigin::signed(ALICE),
-				Box::new(VersionedXcm::from(Xcm(vec![WithdrawAsset(((0, Here), AMOUNT).into())]))),
-				Weight::from_ref_time(MAX_WEIGHT as u64)
-			));
-			output_events::<trappist::Runtime>();
-			assert_eq!(3, trappist::System::events().len());
-		});
-
-		Base::execute_with(|| {
-			assert_ok!(base::PolkadotXcm::execute(
-				base::RuntimeOrigin::signed(ALICE),
-				Box::new(VersionedXcm::from(Xcm(vec![WithdrawAsset(((0, Here), AMOUNT).into())]))),
-				Weight::from_ref_time(MAX_WEIGHT as u64)
-			));
-			output_events::<base::Runtime>();
-			assert_eq!(1, trappist::System::events().len());
-		});
 	}
 }

--- a/xcm-simulator/src/parachains/base.rs
+++ b/xcm-simulator/src/parachains/base.rs
@@ -22,12 +22,14 @@ use base_runtime::{
 		fee::WeightToFee,
 	},
 	xcm_config::{
-		Barrier, CollatorSelectionUpdateOrigin, LocationToAccountId, MaxInstructions,
-		RelayLocation, RelayNetwork, Reserves, SelfReserve, UnitWeightCost, XUsdPerSecond,
+		Barrier, CollatorSelectionUpdateOrigin, FungiblesTransactor, LocationToAccountId,
+		MaxInstructions, RelayLocation, RelayNetwork, Reserves, SelfReserve, UnitWeightCost,
+		XUsdPerSecond,
 	},
 	BlockNumber, DealWithFees, Hash, Header, Index, Period, PotId, RuntimeBlockLength,
 	RuntimeBlockWeights, Session, UnitBody, Version,
 };
+pub use base_runtime::{AccountId, AssetId, Balance};
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{EitherOfDiverse, Everything, Nothing},
@@ -39,8 +41,6 @@ use polkadot_runtime_common::BlockHashCount;
 use sp_core::{ConstU128, ConstU16, ConstU32};
 use sp_runtime::traits::{AccountIdLookup, BlakeTwo256};
 use sp_std::prelude::*;
-use trappist_runtime::xcm_config::{LocalFungiblesTransactor, ReservedFungiblesTransactor};
-pub use trappist_runtime::{AccountId, AssetId, Balance};
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	CurrencyAdapter, EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, IsConcrete,
@@ -162,10 +162,9 @@ parameter_types! {
 	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
 }
 
-pub type LocalAssetTransactor =
-	CurrencyAdapter<Balances, IsConcrete<SelfReserve>, LocationToAccountId, AccountId, ()>;
-pub type AssetTransactors =
-	(LocalAssetTransactor, ReservedFungiblesTransactor, LocalFungiblesTransactor);
+pub type AssetTransactors = (CurrencyTransactor, FungiblesTransactor);
+pub type CurrencyTransactor =
+	CurrencyAdapter<Balances, IsConcrete<RelayLocation>, LocationToAccountId, AccountId, ()>;
 pub type XcmOriginToTransactDispatchOrigin = (
 	SovereignSignedViaLocation<LocationToAccountId, RuntimeOrigin>,
 	RelayChainAsNative<RelayChainOrigin, RuntimeOrigin>,

--- a/xcm-simulator/src/parachains/trappist.rs
+++ b/xcm-simulator/src/parachains/trappist.rs
@@ -169,10 +169,10 @@ parameter_types! {
 	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
 }
 
-pub type LocalAssetTransactor =
-	CurrencyAdapter<Balances, IsConcrete<SelfReserve>, LocationToAccountId, AccountId, ()>;
 pub type AssetTransactors =
 	(LocalAssetTransactor, ReservedFungiblesTransactor, LocalFungiblesTransactor);
+pub type LocalAssetTransactor =
+	CurrencyAdapter<Balances, IsConcrete<SelfReserve>, LocationToAccountId, AccountId, ()>;
 pub type XcmOriginToTransactDispatchOrigin = (
 	SovereignSignedViaLocation<LocationToAccountId, RuntimeOrigin>,
 	RelayChainAsNative<RelayChainOrigin, RuntimeOrigin>,


### PR DESCRIPTION
Additional type aliases defined within mock base runtime to correctly resolve types, rather than re-using from actual runtimes.

Also added small helper function for optionally outputting events, useful when debugging.