### PR TITLE
fix: integration test formatting

### DIFF
--- a/integration-tests/asset-registry/0_reserve_transfer.yml
+++ b/integration-tests/asset-registry/0_reserve_transfer.yml
@@ -95,14 +95,14 @@ tests:
                           - type: Result<Null, SpRuntimeDispatchError>
                             value: Ok
               - queries:
-                forced_created_asset:
-                  chain: *reserve_parachain
-                  pallet: assets
-                  call: asset
-                  args: [ *reserve_asset_id ]
+                  forced_created_asset:
+                    chain: *reserve_parachain
+                    pallet: assets
+                    call: asset
+                    args: [ *reserve_asset_id ]
               - asserts:
-                isSome:
-                  args: [ $forced_created_asset ]
+                  isSome:
+                    args: [ $forced_created_asset ]
 
           - name: DEPENDENCY | Mint assets on Reserve Parachain
             actions:
@@ -140,14 +140,14 @@ tests:
                             value: Ok
                       - name: assets.ForceCreated
               - queries:
-                forced_created_asset:
-                  chain: *trappist_parachain
-                  pallet: assets
-                  call: asset
-                  args: [ *trappist_asset_id ]
+                  forced_created_asset:
+                    chain: *trappist_parachain
+                    pallet: assets
+                    call: asset
+                    args: [ *trappist_asset_id ]
               - asserts:
-                isSome:
-                args: [ $forced_created_asset ]
+                  isSome:
+                    args: [ $forced_created_asset ]
 
         its:
           - name: Trappist Parachain has AssetId registered to Reserve Asset
@@ -227,7 +227,7 @@ tests:
                           - type: XcmV2TraitsOutcome
                             xcmOutcome: Complete
                             threshold: [10, 10]
-                            value: 1,000,000,000
+                            value: 654,608,000
                       - name: assets.Transferred
                         attributes:
                           - type: AccountId32


### PR DESCRIPTION
The latest release version of the `parachains-integration-tests` tool (v2.1) added yaml test file format validation (enforcement).