### PR TITLE
ci: add deterministic build option

### DIFF
--- a/.github/workflows/build-runtime.yaml
+++ b/.github/workflows/build-runtime.yaml
@@ -21,11 +21,11 @@ jobs:
           echo Summary:
           echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.chain }}-srtool-digest.json
           cat ${{ matrix.chain }}-srtool-digest.json
-          echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
+          cp `dirname ${{ steps.srtool_build.outputs.wasm }}`/*.wasm ./
       - name: Archive Runtime
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.chain }}-runtime-${{ github.sha }}
           path: |
-            ${{ steps.srtool_build.outputs.wasm }}
+            ${{ matrix.chain }}*.wasm
             ${{ matrix.chain }}-srtool-digest.json


### PR DESCRIPTION
Quick PR based on https://docs.substrate.io/build/build-a-deterministic-runtime, adding an optional workflow which performs a deterministic build using Substrate Runtime Toolbox: `srtool`.

Workflows set as `workflow_dispatch`, so will only run on manual trigger.