### PR TITLE
Align Trappist runtime w/ Contracts Rococo testnet runtime v0.9.37

### DIFF
--- a/runtime/trappist/src/constants.rs
+++ b/runtime/trappist/src/constants.rs
@@ -26,8 +26,8 @@ pub mod currency {
 	pub const MILLICENTS: Balance = constants::currency::MILLICENTS;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		// map to 1/10 of what the kusama relay chain charges (v9020)
-		constants::currency::deposit(items, bytes) / 10
+		// map to 1/100 of what the kusama relay chain charges (v9020)
+		constants::currency::deposit(items, bytes) / 100
 	}
 }
 
@@ -59,7 +59,7 @@ pub mod fee {
 	impl WeightToFeePolynomial for WeightToFee {
 		type Balance = Balance;
 		fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-			// in Kusama, extrinsic stout weight (smallest non-zero weight) is mapped to 1/10 CENT:
+			// in Kusama, extrinsic base weight (smallest non-zero weight) is mapped to 1/10 CENT:
 			// in Statemine, we map to 1/10 of that, or 1/100 CENT
 			let p = super::currency::CENTS;
 			let q = 100 * Balance::from(ExtrinsicBaseWeight::get().ref_time());

--- a/runtime/trappist/src/contracts.rs
+++ b/runtime/trappist/src/contracts.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use frame_support::{
 	parameter_types,
-	traits::{ConstU32, Nothing},
+	traits::{ConstBool, ConstU32, Nothing},
 	weights::Weight,
 };
 use pallet_contracts::{
@@ -12,7 +12,6 @@ use pallet_contracts::{
 	Config, DefaultAddressGenerator, Frame, Schedule,
 };
 pub use parachains_common::AVERAGE_ON_INITIALIZE_RATIO;
-use sp_core::ConstBool;
 
 // Prints debug output of the `contracts` pallet to stdout if the node is
 // started with `-lruntime::contracts=debug`.
@@ -26,10 +25,10 @@ parameter_types! {
 		RuntimeBlockWeights::get().max_block;
 	// The weight needed for decoding the queue should be less or equal than a fifth
 	// of the overall weight dedicated to the lazy deletion.
-	pub DeletionQueueDepth: u32 = ((DeletionWeightLimit::get() / (
-			<Runtime as Config>::WeightInfo::on_initialize_per_queue_item(1) -
-			<Runtime as Config>::WeightInfo::on_initialize_per_queue_item(0)
-		).ref_time()) / 5).ref_time() as u32;
+	pub DeletionQueueDepth: u32 = ((DeletionWeightLimit::get().ref_time() / (
+		<Runtime as Config>::WeightInfo::on_initialize_per_queue_item(1).ref_time() -
+		<Runtime as Config>::WeightInfo::on_initialize_per_queue_item(0).ref_time()
+	)) / 5) as u32;
 	pub MySchedule: Schedule<Runtime> = Default::default();
 }
 
@@ -58,6 +57,6 @@ impl Config for Runtime {
 	type AddressGenerator = DefaultAddressGenerator;
 	type MaxCodeLen = ConstU32<{ 128 * 1024 }>;
 	type MaxStorageKeyLen = ConstU32<128>;
-	type UnsafeUnstableInterface = ConstBool<false>;
+	type UnsafeUnstableInterface = ConstBool<true>;
 	type MaxDebugBufferLen = ConstU32<{ 2 * 1024 * 1024 }>;
 }

--- a/runtime/trappist/src/lib.rs
+++ b/runtime/trappist/src/lib.rs
@@ -103,7 +103,7 @@ pub type UncheckedExtrinsic =
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra>;
 
-pub type Migrations = (pallet_contracts::Migration<Runtime>,);
+pub type Migrations = (pallet_contracts::Migration<Runtime>);
 
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<

--- a/runtime/trappist/src/lib.rs
+++ b/runtime/trappist/src/lib.rs
@@ -102,6 +102,9 @@ pub type UncheckedExtrinsic =
 	generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra>;
+
+pub type Migrations = (pallet_contracts::Migration<Runtime>,);
+
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
 	Runtime,
@@ -109,7 +112,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	pallet_contracts::Migration<Runtime>,
+	Migrations,
 >;
 
 impl_opaque_keys! {
@@ -290,7 +293,7 @@ impl parachain_info::Config for Runtime {}
 impl cumulus_pallet_aura_ext::Config for Runtime {}
 
 parameter_types! {
-	pub const Period: u32 = 6 * HOURS;
+	pub const Period: u32 = 10 * MINUTES;
 	pub const Offset: u32 = 0;
 }
 
@@ -324,7 +327,7 @@ impl pallet_collator_selection::Config for Runtime {
 	type UpdateOrigin = CollatorSelectionUpdateOrigin;
 	type PotId = PotId;
 	type MaxCandidates = ConstU32<1000>;
-	type MinCandidates = ConstU32<5>;
+	type MinCandidates = ConstU32<0>;
 	type MaxInvulnerables = ConstU32<100>;
 	// should be a multiple of session or things will get inconsistent
 	type KickThreshold = Period;
@@ -555,22 +558,24 @@ construct_runtime!(
 		DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>} = 33,
 
 		// Runtime features
-		Sudo: pallet_sudo = 40,
-		Contracts: pallet_contracts = 41,
-		Council: pallet_collective::<Instance1> = 42,
-		Assets: pallet_assets = 43,
-		Identity: pallet_identity = 44,
-		Uniques: pallet_uniques = 45,
-		Scheduler: pallet_scheduler = 46,
-		Utility: pallet_utility = 47,
-		Preimage: pallet_preimage = 48,
-		Multisig: pallet_multisig = 49,
+		Contracts: pallet_contracts = 40,
+		Council: pallet_collective::<Instance1> = 41,
+		Assets: pallet_assets = 42,
+		Identity: pallet_identity = 43,
+		Uniques: pallet_uniques = 44,
+		Scheduler: pallet_scheduler = 45,
+		Preimage: pallet_preimage = 46,
 
-		Spambot: cumulus_ping::{Pallet, Call, Storage, Event<T>} = 99,
+		// Handy utilities.
+		Utility: pallet_utility::{Pallet, Call, Event} = 50,
+		Multisig: pallet_multisig::{Pallet, Call, Storage, Event<T>} = 51,
+
+		// Sudo
+		Sudo: pallet_sudo::{Pallet, Call, Config<T>, Event<T>, Storage} = 100,
 
 		// Additional pallets
-		Dex: pallet_dex::{Pallet, Call, Storage, Event<T>} = 100,
-		AssetRegistry: pallet_asset_registry::{Pallet, Call, Storage, Event<T>} = 101,
+		Dex: pallet_dex::{Pallet, Call, Storage, Event<T>} = 110,
+		AssetRegistry: pallet_asset_registry::{Pallet, Call, Storage, Event<T>} = 111,
 
 		// Chess
 		Chess: pallet_chess::{Pallet, Call, Storage, Event<T>} = 120,

--- a/runtime/trappist/src/xcm_config.rs
+++ b/runtime/trappist/src/xcm_config.rs
@@ -323,10 +323,3 @@ impl cumulus_pallet_dmp_queue::Config for Runtime {
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
 }
-
-impl cumulus_ping::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
-	type XcmSender = XcmRouter;
-}


### PR DESCRIPTION
closes #154 

- Reduce deposit to 100th of the relay chain's (from a 10th)
- Reduce collator session length & enable contracts pallet unstable interface (as per https://github.com/paritytech/cumulus/pull/1748)
- Re-order pallets to retain the IDs from Contracts-rococo runtime (might not be needed but if anything relies on them on the Contracts testnet, this will make it transparent to migrate ... and it doesn't change anything for Trappist as they chain wasn't live before)
- Remove Cumulus spambot (aka Cumulus ping)