### PR TITLE
Updated pallet-dex branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5808,7 +5808,7 @@ dependencies = [
 [[package]]
 name = "pallet-dex"
 version = "0.0.1"
-source = "git+https://github.com/paritytech/substrate-dex.git#4a1588fa80cf9ad777601020c2680227c5c450ec"
+source = "git+https://github.com/paritytech/substrate-dex.git?branch=polkadot-v0.9.37#4a1588fa80cf9ad777601020c2680227c5c450ec"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5822,7 +5822,7 @@ dependencies = [
 [[package]]
 name = "pallet-dex-rpc"
 version = "0.0.1"
-source = "git+https://github.com/paritytech/substrate-dex.git#4a1588fa80cf9ad777601020c2680227c5c450ec"
+source = "git+https://github.com/paritytech/substrate-dex.git?branch=polkadot-v0.9.37#4a1588fa80cf9ad777601020c2680227c5c450ec"
 dependencies = [
  "jsonrpsee",
  "pallet-dex-rpc-runtime-api",
@@ -5835,7 +5835,7 @@ dependencies = [
 [[package]]
 name = "pallet-dex-rpc-runtime-api"
 version = "0.0.1"
-source = "git+https://github.com/paritytech/substrate-dex.git#4a1588fa80cf9ad777601020c2680227c5c450ec"
+source = "git+https://github.com/paritytech/substrate-dex.git?branch=polkadot-v0.9.37#4a1588fa80cf9ad777601020c2680227c5c450ec"
 dependencies = [
  "pallet-dex",
  "parity-scale-codec",

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -95,7 +95,7 @@ polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "r
 xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.37" }
 
 # External Dependencies
-pallet-dex-rpc = { version = "0.0.1", git = "https://github.com/paritytech/substrate-dex.git", default-features = false }
+pallet-dex-rpc = { version = "0.0.1", git = "https://github.com/paritytech/substrate-dex.git", default-features = false, branch = "polkadot-v0.9.37" }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -27,6 +27,6 @@ sc-consensus-manual-seal = { git = "https://github.com/paritytech/substrate", br
 parachains-common = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.37", default-features = false }
 
 # External Dependencies
-pallet-dex-rpc = { version = "0.0.1", git = "https://github.com/paritytech/substrate-dex.git", default-features = false }
+pallet-dex-rpc = { version = "0.0.1", git = "https://github.com/paritytech/substrate-dex.git", default-features = false, branch = "polkadot-v0.9.37" }
 
 trappist-runtime = { path = "../runtime/trappist" }

--- a/runtime/stout/Cargo.toml
+++ b/runtime/stout/Cargo.toml
@@ -94,8 +94,8 @@ xcm-executor = { git = "https://github.com/paritytech/polkadot", default-feature
 xcm-primitives = { path = "../../primitives/xcm", default-features = false }
 
 # External Pallets
-pallet-dex = { version = "0.0.1", git = "https://github.com/paritytech/substrate-dex.git", default-features = false }
-pallet-dex-rpc-runtime-api = { version = "0.0.1", git = "https://github.com/paritytech/substrate-dex.git", default-features = false }
+pallet-dex = { version = "0.0.1", git = "https://github.com/paritytech/substrate-dex.git", default-features = false, branch = "polkadot-v0.9.37" }
+pallet-dex-rpc-runtime-api = { version = "0.0.1", git = "https://github.com/paritytech/substrate-dex.git", default-features = false, branch = "polkadot-v0.9.37" }
 
 [features]
 default = ["std"]

--- a/runtime/trappist/Cargo.toml
+++ b/runtime/trappist/Cargo.toml
@@ -99,8 +99,8 @@ xcm-executor = { git = "https://github.com/paritytech/polkadot", default-feature
 xcm-primitives = { path = "../../primitives/xcm", default-features = false }
 
 # External Pallets
-pallet-dex = { version = "0.0.1", git = "https://github.com/paritytech/substrate-dex.git", default-features = false }
-pallet-dex-rpc-runtime-api = { version = "0.0.1", git = "https://github.com/paritytech/substrate-dex.git", default-features = false }
+pallet-dex = { version = "0.0.1", git = "https://github.com/paritytech/substrate-dex.git", default-features = false, branch = "polkadot-v0.9.37" }
+pallet-dex-rpc-runtime-api = { version = "0.0.1", git = "https://github.com/paritytech/substrate-dex.git", default-features = false, branch = "polkadot-v0.9.37" }
 pallet-chess = { git = "https://github.com/SubstrateChess/pallet-chess.git", default-features = false, branch = "polkadot-v0.9.37" }
 
 # Trappist Pallets


### PR DESCRIPTION
Quick fix for pre-upgraded version of Trappist to be deployed on Rococo to point to proper branch of pallet-dex 