### PR TITLE
Add lockdown mode activation to lockdown-mode pallet's `GenesisConfig`

### DIFF
--- a/pallets/lockdown-mode/src/benchmarking.rs
+++ b/pallets/lockdown-mode/src/benchmarking.rs
@@ -14,12 +14,12 @@ benchmarks! {
 		assert_eq!(LockdownModeStatus::<T>::get(), ACTIVATED);
 	}
 
-	 deactivate_lockdown_mode {
+	deactivate_lockdown_mode {
 		LockdownModeStatus::<T>::put(ACTIVATED);
 	}: deactivate_lockdown_mode(RawOrigin::Root)
 	verify {
 		assert_eq!(LockdownModeStatus::<T>::get(), DEACTIVATED);
 	}
 
-	impl_benchmark_test_suite!(LockdownMode, crate::mock::new_test_ext(), crate::mock::Test);
+	impl_benchmark_test_suite!(LockdownMode, crate::mock::new_test_ext(true), crate::mock::Test);
 }

--- a/pallets/lockdown-mode/src/lib.rs
+++ b/pallets/lockdown-mode/src/lib.rs
@@ -35,15 +35,22 @@ pub mod pallet {
 	#[pallet::generate_store(pub(super) trait Store)]
 	pub struct Pallet<T>(_);
 
-	#[derive(Default)]
 	#[pallet::genesis_config]
-	/// Genesis config for lockdown mode pallet
-	pub struct GenesisConfig {}
+	pub struct GenesisConfig {
+		pub activated: bool,
+	}
+
+	#[cfg(feature = "std")]
+	impl Default for GenesisConfig {
+		fn default() -> Self {
+			Self { activated: ACTIVATED }
+		}
+	}
 
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig {
 		fn build(&self) {
-			LockdownModeStatus::<T>::put(ACTIVATED);
+			LockdownModeStatus::<T>::put(&self.activated);
 		}
 	}
 

--- a/pallets/lockdown-mode/src/lib.rs
+++ b/pallets/lockdown-mode/src/lib.rs
@@ -135,7 +135,7 @@ pub mod pallet {
 			if LockdownModeStatus::<T>::get() {
 				T::BlackListedCalls::contains(call)
 			} else {
-				return true;
+				return true
 			}
 		}
 	}

--- a/pallets/lockdown-mode/src/lib.rs
+++ b/pallets/lockdown-mode/src/lib.rs
@@ -135,7 +135,7 @@ pub mod pallet {
 			if LockdownModeStatus::<T>::get() {
 				T::BlackListedCalls::contains(call)
 			} else {
-				return true
+				return true;
 			}
 		}
 	}

--- a/pallets/lockdown-mode/src/lib.rs
+++ b/pallets/lockdown-mode/src/lib.rs
@@ -37,20 +37,20 @@ pub mod pallet {
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig {
-		pub activated: bool,
+		pub initial_status: bool,
 	}
 
 	#[cfg(feature = "std")]
 	impl Default for GenesisConfig {
 		fn default() -> Self {
-			Self { activated: ACTIVATED }
+			Self { initial_status: ACTIVATED }
 		}
 	}
 
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig {
 		fn build(&self) {
-			LockdownModeStatus::<T>::put(&self.activated);
+			LockdownModeStatus::<T>::put(&self.initial_status);
 		}
 	}
 

--- a/pallets/lockdown-mode/src/mock.rs
+++ b/pallets/lockdown-mode/src/mock.rs
@@ -119,10 +119,10 @@ impl pallet_lockdown_mode::Config for Test {
 	type WeightInfo = pallet_lockdown_mode::weights::SubstrateWeight<Test>;
 }
 
-pub fn new_test_ext(activated: bool) -> sp_io::TestExternalities {
+pub fn new_test_ext(initial_status: bool) -> sp_io::TestExternalities {
 	let mut storage = system::GenesisConfig::default().build_storage::<Test>().unwrap();
 	GenesisBuild::<Test>::assimilate_storage(
-		&pallet_lockdown_mode::GenesisConfig { activated },
+		&pallet_lockdown_mode::GenesisConfig { initial_status },
 		&mut storage,
 	)
 	.unwrap();

--- a/pallets/lockdown-mode/src/mock.rs
+++ b/pallets/lockdown-mode/src/mock.rs
@@ -1,7 +1,7 @@
 use crate as pallet_lockdown_mode;
 use cumulus_primitives_core::{relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler};
 use frame_support::{
-	traits::{ConstU16, ConstU64, Contains},
+	traits::{ConstU16, ConstU64, Contains, GenesisBuild},
 	weights::Weight,
 };
 use frame_system as system;
@@ -119,8 +119,12 @@ impl pallet_lockdown_mode::Config for Test {
 	type WeightInfo = pallet_lockdown_mode::weights::SubstrateWeight<Test>;
 }
 
-// Build genesis storage according to the mock runtime.
-pub fn new_test_ext() -> sp_io::TestExternalities {
-	let storage = system::GenesisConfig::default().build_storage::<Test>().unwrap();
+pub fn new_test_ext(activated: bool) -> sp_io::TestExternalities {
+	let mut storage = system::GenesisConfig::default().build_storage::<Test>().unwrap();
+	GenesisBuild::<Test>::assimilate_storage(
+		&pallet_lockdown_mode::GenesisConfig { activated },
+		&mut storage,
+	)
+	.unwrap();
 	storage.into()
 }

--- a/pallets/lockdown-mode/src/tests.rs
+++ b/pallets/lockdown-mode/src/tests.rs
@@ -7,7 +7,7 @@ use pallet_remark::{self, Call as RemarkCall};
 #[test]
 fn genesis_config_default() {
 	let default_genesis = GenesisConfig::default();
-	assert_eq!(default_genesis.activated, ACTIVATED);
+	assert_eq!(default_genesis.initial_status, ACTIVATED);
 }
 
 #[test]

--- a/pallets/lockdown-mode/src/tests.rs
+++ b/pallets/lockdown-mode/src/tests.rs
@@ -1,12 +1,28 @@
-use super::*;
+use super::{*, GenesisConfig};
 use crate::{mock::*, Error, ACTIVATED, DEACTIVATED};
 use frame_support::{assert_noop, assert_ok, traits::Contains};
 use pallet_balances::{self, Call as BalancesCall};
 use pallet_remark::{self, Call as RemarkCall};
 
 #[test]
+fn genesis_config_default() {
+	let default_genesis = GenesisConfig::default();
+	assert_eq!(default_genesis.activated, ACTIVATED);
+}
+
+#[test]
+fn genesis_config_initialized() {
+	[true, false].into_iter().for_each(|expected| {
+		new_test_ext(expected).execute_with(|| {
+			let lockdown_mode = LockdownModeStatus::<Test>::get();
+			assert_eq!(lockdown_mode, expected);
+		});
+	});
+}
+
+#[test]
 fn activate_lockdown_mode_works() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(false).execute_with(|| {
 		assert_eq!(LockdownModeStatus::<Test>::get(), DEACTIVATED);
 		assert_ok!(LockdownMode::activate_lockdown_mode(RuntimeOrigin::root()));
 
@@ -22,7 +38,7 @@ fn activate_lockdown_mode_works() {
 
 #[test]
 fn deactivate_lockdown_mode_works() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(false).execute_with(|| {
 		// We activate lockdown mode first so we can deactivate it.
 		assert_ok!(LockdownMode::activate_lockdown_mode(RuntimeOrigin::root()));
 
@@ -40,7 +56,7 @@ fn deactivate_lockdown_mode_works() {
 
 #[test]
 fn call_not_filtered_in_lockdown_mode() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(false).execute_with(|| {
 		assert_ok!(LockdownMode::activate_lockdown_mode(RuntimeOrigin::root()));
 		let remark_call = RuntimeCall::Remark(RemarkCall::store { remark: vec![1, 2, 3] });
 		let result: bool = LockdownMode::contains(&remark_call);
@@ -50,7 +66,7 @@ fn call_not_filtered_in_lockdown_mode() {
 
 #[test]
 fn call_filtered_in_lockdown_mode() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(false).execute_with(|| {
 		assert_ok!(LockdownMode::activate_lockdown_mode(RuntimeOrigin::root()));
 		let balance_call = RuntimeCall::Balance(BalancesCall::transfer { dest: 1, value: 2 });
 
@@ -61,7 +77,7 @@ fn call_filtered_in_lockdown_mode() {
 
 #[test]
 fn call_not_filtered_in_normal_mode() {
-	new_test_ext().execute_with(|| {
+	new_test_ext(false).execute_with(|| {
 		let lockdown_mode = LockdownModeStatus::<Test>::get();
 		assert_eq!(lockdown_mode, DEACTIVATED);
 		let balance_call = RuntimeCall::Balance(BalancesCall::transfer { dest: 1, value: 2 });

--- a/pallets/lockdown-mode/src/tests.rs
+++ b/pallets/lockdown-mode/src/tests.rs
@@ -1,4 +1,4 @@
-use super::{*, GenesisConfig};
+use super::{GenesisConfig, *};
 use crate::{mock::*, Error, ACTIVATED, DEACTIVATED};
 use frame_support::{assert_noop, assert_ok, traits::Contains};
 use pallet_balances::{self, Call as BalancesCall};

--- a/pallets/lockdown-mode/src/tests.rs
+++ b/pallets/lockdown-mode/src/tests.rs
@@ -23,7 +23,6 @@ fn genesis_config_initialized() {
 #[test]
 fn activate_lockdown_mode_works() {
 	new_test_ext(false).execute_with(|| {
-		assert_eq!(LockdownModeStatus::<Test>::get(), DEACTIVATED);
 		assert_ok!(LockdownMode::activate_lockdown_mode(RuntimeOrigin::root()));
 
 		let lockdown_mode = LockdownModeStatus::<Test>::get();

--- a/pallets/lockdown-mode/src/tests.rs
+++ b/pallets/lockdown-mode/src/tests.rs
@@ -37,10 +37,7 @@ fn activate_lockdown_mode_works() {
 
 #[test]
 fn deactivate_lockdown_mode_works() {
-	new_test_ext(false).execute_with(|| {
-		// We activate lockdown mode first so we can deactivate it.
-		assert_ok!(LockdownMode::activate_lockdown_mode(RuntimeOrigin::root()));
-
+	new_test_ext(true).execute_with(|| {
 		assert_ok!(LockdownMode::deactivate_lockdown_mode(RuntimeOrigin::root()));
 
 		let lockdown_mode = LockdownModeStatus::<Test>::get();


### PR DESCRIPTION
Lockdown mode ACTIVATED or DEACTIVATED is now part of the `GenesisConfig` of this pallet.

By default, the pallet will start with lockdown mode activated.

Closes: https://github.com/paritytech/trappist/issues/172