### PR TITLE
Lockdown DmpMessageHandler fix

### DIFF
--- a/runtime/trappist/src/impls.rs
+++ b/runtime/trappist/src/impls.rs
@@ -97,7 +97,7 @@ impl DmpMessageHandler for LockdownDmpHandler {
 		_iter: impl Iterator<Item = (RelayBlockNumber, Vec<u8>)>,
 		limit: Weight,
 	) -> Weight {
-		limit
+		DmpQueue::handle_dmp_messages(_iter, limit)
 	}
 }
 

--- a/xcm-playground.toml
+++ b/xcm-playground.toml
@@ -62,6 +62,24 @@ chain = "trappist-local"
   ws_port = 9921
   args = ["--log=xcm=trace,pallet-assets=trace"]
 
+[[parachains]]
+id = 3000
+add_to_genesis = true
+cumulus_based = true
+chain = "stout-local"
+
+  [[parachains.collators]]
+  name = "stout-collator01"
+  command = "./target_stout/release/stout-collator"
+  ws_port = 9930
+  args = ["--log=xcm=trace,pallet-assets=trace"]
+
+  [[parachains.collators]]
+  name = "stout-collator02"
+  command = "./target_stout/release/stout-collator"
+  ws_port = 9931
+  args = ["--log=xcm=trace,pallet-assets=trace"]
+
 [types.Header]
 number = "u64"
 parent_hash = "Hash"
@@ -79,3 +97,26 @@ recipient = 1000
 max_capacity = 8
 max_message_size = 512
 
+[[hrmp_channels]]
+sender = 1000
+recipient = 3000
+max_capacity = 8
+max_message_size = 512
+
+[[hrmp_channels]]
+sender = 3000
+recipient = 1000
+max_capacity = 8
+max_message_size = 512
+
+[[hrmp_channels]]
+sender = 1836
+recipient = 3000
+max_capacity = 8
+max_message_size = 512
+
+[[hrmp_channels]]
+sender = 3000
+recipient = 1836
+max_capacity = 8
+max_message_size = 512

--- a/xcm-playground.toml
+++ b/xcm-playground.toml
@@ -62,24 +62,6 @@ chain = "trappist-local"
   ws_port = 9921
   args = ["--log=xcm=trace,pallet-assets=trace"]
 
-[[parachains]]
-id = 3000
-add_to_genesis = true
-cumulus_based = true
-chain = "stout-local"
-
-  [[parachains.collators]]
-  name = "stout-collator01"
-  command = "./target_stout/release/stout-collator"
-  ws_port = 9930
-  args = ["--log=xcm=trace,pallet-assets=trace"]
-
-  [[parachains.collators]]
-  name = "stout-collator02"
-  command = "./target_stout/release/stout-collator"
-  ws_port = 9931
-  args = ["--log=xcm=trace,pallet-assets=trace"]
-
 [types.Header]
 number = "u64"
 parent_hash = "Hash"
@@ -97,26 +79,3 @@ recipient = 1000
 max_capacity = 8
 max_message_size = 512
 
-[[hrmp_channels]]
-sender = 1000
-recipient = 3000
-max_capacity = 8
-max_message_size = 512
-
-[[hrmp_channels]]
-sender = 3000
-recipient = 1000
-max_capacity = 8
-max_message_size = 512
-
-[[hrmp_channels]]
-sender = 1836
-recipient = 3000
-max_capacity = 8
-max_message_size = 512
-
-[[hrmp_channels]]
-sender = 3000
-recipient = 1836
-max_capacity = 8
-max_message_size = 512


### PR DESCRIPTION
Fixes a previous error in the Lockdown `DmpMessageHandler` that would cause the chain to execute an Unreachable WASM instruction preventing the chain from producing blocks.

This was caused after replacing `DmpQueue` for `LockdownMode`in `cumulus_pallet_parachain_system`
```rust
impl cumulus_pallet_parachain_system::Config for Runtime {
	....
	type DmpMessageHandler = LockdownMode;
	....
}
```


