### PR TITLE
Adding dex pallet to stout

### DIFF
--- a/node/service/src/chain_spec/stout.rs
+++ b/node/service/src/chain_spec/stout.rs
@@ -228,5 +228,6 @@ fn testnet_genesis(
 			members: invulnerables.iter().map(|x| x.0.clone()).collect::<Vec<_>>(),
 			phantom: Default::default(),
 		},
+		dex: Default::default(),
 	}
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -86,6 +86,7 @@ where
 	Ok(module)
 }
 
+/// This function will be removed during the node refactor.
 /// Instantiate all RPCs we want at the canvas-kusama chain.
 pub fn stout_create_full<C, P>(
 	deps: FullDeps<C, P>,
@@ -101,9 +102,16 @@ where
 		+ 'static,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
+	C::Api: pallet_dex_rpc::DexRuntimeApi<
+		trappist_runtime::opaque::Block,
+		trappist_runtime::AssetId,
+		trappist_runtime::Balance,
+		trappist_runtime::AssetBalance,
+	>,
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + Sync + Send + 'static,
 {
+	use pallet_dex_rpc::{Dex, DexApiServer};
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
 	use sc_rpc::dev::{Dev, DevApiServer};
 	use substrate_frame_rpc_system::{System, SystemApiServer};
@@ -114,6 +122,7 @@ where
 	module.merge(System::new(client.clone(), pool.clone(), deny_unsafe).into_rpc())?;
 	module.merge(TransactionPayment::new(client.clone()).into_rpc())?;
 	module.merge(Dev::new(client.clone(), deny_unsafe).into_rpc())?;
+	module.merge(Dex::new(client).into_rpc())?;
 
 	// Extend this RPC with a custom API by using the following syntax.
 	// `YourRpcStruct` should have a reference to a client, which is needed

--- a/runtime/stout/src/lib.rs
+++ b/runtime/stout/src/lib.rs
@@ -475,6 +475,26 @@ impl pallet_preimage::Config for Runtime {
 	type ByteDeposit = PreimageByteDeposit;
 }
 
+parameter_types! {
+	pub const DexPalletId: PalletId = PalletId(*b"trap/dex");
+}
+
+impl pallet_dex::Config for Runtime {
+	type PalletId = DexPalletId;
+	type RuntimeEvent = RuntimeEvent;
+	type Currency = Balances;
+	type AssetBalance = AssetBalance;
+	type AssetToCurrencyBalance = sp_runtime::traits::Identity;
+	type CurrencyToAssetBalance = sp_runtime::traits::Identity;
+	type AssetId = AssetId;
+	type Assets = Assets;
+	type AssetRegistry = Assets;
+	type WeightInfo = pallet_dex::weights::SubstrateWeight<Runtime>;
+	type ProviderFeeNumerator = ConstU128<3>;
+	type ProviderFeeDenominator = ConstU128<1000>;
+	type MinDeposit = ConstU128<{ UNITS }>;
+}
+
 // Create the runtime by composing the FRAME pallets that were previously configured.
 construct_runtime!(
 	pub enum Runtime where
@@ -520,6 +540,7 @@ construct_runtime!(
 		Utility: pallet_utility = 47,
 		Preimage: pallet_preimage = 48,
 		Multisig: pallet_multisig = 49,
+		Dex: pallet_dex = 50,
 
 		Spambot: cumulus_ping::{Pallet, Call, Storage, Event<T>} = 99,
 	}
@@ -543,6 +564,7 @@ mod benches {
 		[pallet_identity, Identity]
 		[pallet_multisig, Multisig]
 		[pallet_uniques, Uniques]
+		[pallet_dex, Dex]
 		[pallet_scheduler, Scheduler]
 		[pallet_utility, Utility]
 		[cumulus_pallet_xcmp_queue, XcmpQueue]
@@ -626,6 +648,36 @@ impl_runtime_apis! {
 			encoded: Vec<u8>,
 		) -> Option<Vec<(Vec<u8>, KeyTypeId)>> {
 			SessionKeys::decode_into_raw_public_keys(&encoded)
+		}
+	}
+
+	impl pallet_dex_rpc_runtime_api::DexApi<Block, AssetId, Balance, AssetBalance> for Runtime {
+		fn get_currency_to_asset_output_amount(
+			asset_id: AssetId,
+			currency_amount: Balance
+		) -> pallet_dex_rpc_runtime_api::RpcResult<AssetBalance> {
+			Dex::get_currency_to_asset_output_amount(asset_id, currency_amount)
+		}
+
+		fn get_currency_to_asset_input_amount(
+			asset_id: AssetId,
+			token_amount: AssetBalance
+		) -> pallet_dex_rpc_runtime_api::RpcResult<Balance> {
+			Dex::get_currency_to_asset_input_amount(asset_id, token_amount)
+		}
+
+		fn get_asset_to_currency_output_amount(
+			asset_id: AssetId,
+			token_amount: AssetBalance
+		) -> pallet_dex_rpc_runtime_api::RpcResult<Balance> {
+			Dex::get_asset_to_currency_output_amount(asset_id, token_amount)
+		}
+
+		fn get_asset_to_currency_input_amount(
+			asset_id: AssetId,
+			currency_amount: Balance
+		) -> pallet_dex_rpc_runtime_api::RpcResult<AssetBalance> {
+			Dex::get_asset_to_currency_input_amount(asset_id, currency_amount)
 		}
 	}
 


### PR DESCRIPTION
Closes #203.

This PR is simple a concise: Adds the DEX pallet to stout runtime in order to simplify the service file refactor.