### PR TITLE
chess-pallet removal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,21 +1139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cozy-chess"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0aa2dcdbe66b10019af0f81ee4f404ca12c1d24e56f47e7f2588954f8bfa306"
-dependencies = [
- "cozy-chess-types",
-]
-
-[[package]]
-name = "cozy-chess-types"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4a557c6659b8705d301732f473c9a61659c740ffda3e3485e79d1d4b7a1e12"
-
-[[package]]
 name = "cpp_demangle"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5639,26 +5624,6 @@ dependencies = [
  "frame-system",
  "log",
  "pallet-treasury",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-chess"
-version = "4.0.0-dev"
-source = "git+https://github.com/SubstrateChess/pallet-chess.git?branch=polkadot-v0.9.37#ebd727358e5ec87747d7b02adea0ea78b2c5e77f"
-dependencies = [
- "cozy-chess",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "pallet-assets",
- "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -12225,7 +12190,6 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
- "pallet-chess",
  "pallet-collator-selection",
  "pallet-collective",
  "pallet-contracts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ jsonrpsee = { version = "0.16.2" }
 pallet-dex-rpc = { version = "0.0.1", git = "https://github.com/paritytech/substrate-dex.git", default-features = false, branch = "polkadot-v0.9.37" }
 pallet-dex = { version = "0.0.1", git = "https://github.com/paritytech/substrate-dex.git", default-features = false, branch = "polkadot-v0.9.37" }
 pallet-dex-rpc-runtime-api = { version = "0.0.1", git = "https://github.com/paritytech/substrate-dex.git", default-features = false, branch = "polkadot-v0.9.37" }
-pallet-chess = { git = "https://github.com/SubstrateChess/pallet-chess.git", default-features = false, branch = "polkadot-v0.9.37" }
 
 # Trappist Pallets
 pallet-asset-registry = { default-features = false, path = "pallets/asset-registry" }

--- a/runtime/trappist/Cargo.toml
+++ b/runtime/trappist/Cargo.toml
@@ -99,7 +99,6 @@ pallet-xcm-benchmarks = { workspace = true, optional = true }
 # External Pallets
 pallet-dex = { workspace = true }
 pallet-dex-rpc-runtime-api = { workspace = true }
-pallet-chess = { workspace = true }
 
 # Trappist Pallets
 pallet-asset-registry = {workspace = true }
@@ -134,7 +133,6 @@ std = [
 	"pallet-aura/std",
 	"pallet-authorship/std",
 	"pallet-balances/std",
-	"pallet-chess/std",
 	"pallet-collator-selection/std",
 	"pallet-collective/std",
 	"pallet-contracts/std",

--- a/runtime/trappist/src/impls.rs
+++ b/runtime/trappist/src/impls.rs
@@ -82,7 +82,6 @@ impl Contains<RuntimeCall> for RuntimeBlackListedCalls {
 			RuntimeCall::Dex(_) => false,
 			RuntimeCall::PolkadotXcm(_) => false,
 			RuntimeCall::Treasury(_) => false,
-			RuntimeCall::Chess(_) => false,
 			RuntimeCall::Contracts(_) => false,
 			RuntimeCall::Uniques(_) => false,
 			RuntimeCall::AssetRegistry(_) => false,

--- a/runtime/trappist/src/lib.rs
+++ b/runtime/trappist/src/lib.rs
@@ -587,24 +587,6 @@ impl pallet_asset_registry::Config for Runtime {
 	type BenchmarkHelper = AssetRegistryBenchmarkHelper;
 }
 
-parameter_types! {
-	pub const ChessPalletId: PalletId = PalletId(*b"subchess");
-	pub const IncentiveShare: u8 = 10; // janitor gets 10% of the prize
-}
-
-impl pallet_chess::Config for Runtime {
-	type PalletId = ChessPalletId;
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = pallet_chess::weights::SubstrateWeight<Runtime>;
-	type Assets = Assets;
-	type AssetBalance = u128;
-	type BulletPeriod = ConstU32<{ 1 * MINUTES }>; // ~1 minute
-	type BlitzPeriod = ConstU32<{ 5 * MINUTES }>; // ~5 minutes
-	type RapidPeriod = ConstU32<{ 15 * MINUTES }>; // ~15 minutes
-	type DailyPeriod = ConstU32<{ 25 * HOURS }>; // ~24 hours
-	type IncentiveShare = IncentiveShare;
-}
-
 type TreasuryApproveCancelOrigin = EitherOfDiverse<
 	EnsureRoot<AccountId>,
 	pallet_collective::EnsureProportionAtLeast<AccountId, CouncilCollective, 2, 6>,
@@ -715,8 +697,6 @@ construct_runtime!(
 		Dex: pallet_dex::{Pallet, Call, Storage, Event<T>} = 110,
 		AssetRegistry: pallet_asset_registry::{Pallet, Call, Storage, Event<T>} = 111,
 
-		// Chess
-		Chess: pallet_chess::{Pallet, Call, Storage, Event<T>} = 120,
 	}
 );
 


### PR DESCRIPTION
Removes `pallet_chess` from the Trappist Runtime as discussed in #167  