### PR TITLE
Fix xcm reserve transfer from Rockmine <> Trappist.

### DIFF
--- a/runtime/trappist/src/constants.rs
+++ b/runtime/trappist/src/constants.rs
@@ -73,4 +73,14 @@ pub mod fee {
 			}]
 		}
 	}
+
+	pub fn base_tx_fee() -> Balance {
+		CENTS / 10
+	}
+
+	pub fn default_fee_per_second() -> u128 {
+		let base_weight = Balance::from(ExtrinsicBaseWeight::get().ref_time());
+		let base_tx_per_second = (WEIGHT_REF_TIME_PER_SECOND as u128) / base_weight;
+		base_tx_per_second * base_tx_fee()
+	}
 }

--- a/runtime/trappist/src/weights/xcm/mod.rs
+++ b/runtime/trappist/src/weights/xcm/mod.rs
@@ -56,9 +56,10 @@ impl<Call> XcmWeightInfo<Call> for TrappistXcmWeight<Call> {
 	fn withdraw_asset(assets: &MultiAssets) -> XCMWeight {
 		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::withdraw_asset())
 	}
-	// Currently there is no trusted reserve
+	// Hacked value to make the tests passing. This should be overwritten by the benchmarking
+	// pallet.
 	fn reserve_asset_deposited(_assets: &MultiAssets) -> XCMWeight {
-		u64::MAX
+		10_000u64.into()
 	}
 	fn receive_teleported_asset(assets: &MultiAssets) -> XCMWeight {
 		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::receive_teleported_asset())

--- a/runtime/trappist/src/xcm_config.rs
+++ b/runtime/trappist/src/xcm_config.rs
@@ -43,11 +43,11 @@ use xcm::latest::{prelude::*, Fungibility::Fungible, MultiAsset, MultiLocation};
 use xcm_builder::{
 	AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
 	AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, AsPrefixedGeneralIndex,
-	ConvertedConcreteAssetId, CurrencyAdapter, EnsureXcmOrigin, FungiblesAdapter, IsConcrete,
-	LocationInverter, NativeAsset, ParentAsSuperuser, ParentIsPreset, RelayChainAsNative,
-	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
-	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
-	WeightInfoBounds,
+	ConvertedConcreteAssetId, CurrencyAdapter, EnsureXcmOrigin, FixedWeightBounds,
+	FungiblesAdapter, IsConcrete, LocationInverter, NativeAsset, ParentAsSuperuser, ParentIsPreset,
+	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
+	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
+	UsingComponents, WeightInfoBounds,
 };
 use xcm_executor::XcmExecutor;
 
@@ -211,6 +211,11 @@ parameter_types! {
 	// Rockmine's Assets pallet index
 	pub RockmineAssetsPalletLocation: MultiLocation =
 		MultiLocation::new(1, X2(Parachain(1000), PalletInstance(50)));
+
+	pub RUsdPerSecond: (xcm::v1::AssetId, u128) = (
+		MultiLocation::new(1, X3(Parachain(1000), PalletInstance(50), GeneralIndex(1984))).into(),
+		default_fee_per_second() * 10
+	);
 }
 
 //- From PR https://github.com/paritytech/cumulus/pull/936
@@ -256,7 +261,10 @@ impl xcm_executor::Config for XcmConfig {
 		RuntimeCall,
 		MaxInstructions,
 	>;
-	type Trader = UsingComponents<WeightToFee, SelfReserve, AccountId, Balances, ToAuthor<Runtime>>;
+	type Trader = (
+		FixedRateOfFungible<RUsdPerSecond, ()>,
+		UsingComponents<WeightToFee, SelfReserve, AccountId, Balances, ToAuthor<Runtime>>,
+	);
 	type ResponseHandler = PolkadotXcm;
 	type AssetTrap = TrappistDropAssets<
 		AssetId,

--- a/runtime/trappist/src/xcm_config.rs
+++ b/runtime/trappist/src/xcm_config.rs
@@ -216,6 +216,9 @@ parameter_types! {
 		MultiLocation::new(1, X3(Parachain(1000), PalletInstance(50), GeneralIndex(1984))).into(),
 		default_fee_per_second() * 10
 	);
+	/// Roc = 7 RUSD
+	pub RocPerSecond: (AssetId, u128) = (MultiLocation::parent().into(), default_fee_per_second() * 70);
+
 }
 
 //- From PR https://github.com/paritytech/cumulus/pull/936
@@ -242,6 +245,12 @@ impl<T: Get<MultiLocation>> FilterAssetLocation for ReserveAssetsFrom<T> {
 	}
 }
 
+pub type Trader = (
+	FixedRateOfFungible<RUsdPerSecond, ()>,
+	FixedRateOfFungible<RocPerSecond, ()>,
+	UsingComponents<WeightToFee, SelfReserve, AccountId, Balances, ToAuthor<Runtime>>,
+);
+
 //--
 
 pub type Reserves = (NativeAsset, ReserveAssetsFrom<RockmineLocation>);
@@ -261,10 +270,7 @@ impl xcm_executor::Config for XcmConfig {
 		RuntimeCall,
 		MaxInstructions,
 	>;
-	type Trader = (
-		FixedRateOfFungible<RUsdPerSecond, ()>,
-		UsingComponents<WeightToFee, SelfReserve, AccountId, Balances, ToAuthor<Runtime>>,
-	);
+	type Trader = Trader;
 	type ResponseHandler = PolkadotXcm;
 	type AssetTrap = TrappistDropAssets<
 		AssetId,


### PR DESCRIPTION
This PR fixes the reserve transfer asset from Rockmine to Trappist.

It adds the following Trader tuple:

```rust
pub type Trader = (
	FixedRateOfFungible<RUsdPerSecond, ()>,
	FixedRateOfFungible<RocPerSecond, ()>,
	UsingComponents<WeightToFee, SelfReserve, AccountId, Balances, ToAuthor<Runtime>>,
);
```

As you can see, also `Roc`s can be computed as a reference value of 1 ROC = 7 RUSD"
```rust
	pub RUsdPerSecond: (xcm::v1::AssetId, u128) = (
		MultiLocation::new(1, X3(Parachain(1000), PalletInstance(50), GeneralIndex(1984))).into(),
		default_fee_per_second() * 10
	);
	/// Roc = 7 RUSD
	pub RocPerSecond: (AssetId, u128) = (MultiLocation::parent().into(), default_fee_per_second() * 70);
```

Also there was an issue with the pallet-xcm-benchmarking that was setting the weight for `reserve_asset_deposited ` to `u64::MAX`. I suspect this is a hack for CGP to avoid reserve based transfers from other reserves.