### PR TITLE
Validate `MultiLocation` for asset-registry 

### DIFF
--- a/pallets/asset-registry/src/lib.rs
+++ b/pallets/asset-registry/src/lib.rs
@@ -38,11 +38,9 @@ pub mod pallet {
 	use frame_support::{pallet_prelude::*, traits::tokens::fungibles::Inspect};
 	use frame_system::pallet_prelude::*;
 
-	use xcm::{
-		latest::{
-			Junction::{AccountId32, AccountKey20, GeneralIndex, PalletInstance},
-			MultiLocation,
-		},
+	use xcm::latest::{
+		Junction::{AccountId32, AccountKey20, GeneralIndex, PalletInstance},
+		MultiLocation,
 	};
 
 	#[pallet::pallet]

--- a/pallets/asset-registry/src/lib.rs
+++ b/pallets/asset-registry/src/lib.rs
@@ -38,9 +38,11 @@ pub mod pallet {
 	use frame_support::{pallet_prelude::*, traits::tokens::fungibles::Inspect};
 	use frame_system::pallet_prelude::*;
 
-	use xcm::latest::{
-		Junction::{AccountId32, AccountKey20, GeneralIndex, PalletInstance},
-		MultiLocation,
+	use xcm::{
+		latest::{
+			Junction::{AccountId32, AccountKey20, GeneralIndex, PalletInstance},
+			MultiLocation,
+		},
 	};
 
 	#[pallet::pallet]
@@ -153,26 +155,22 @@ pub mod pallet {
 		fn valid_asset_location(location: &MultiLocation) -> bool {
 			let (split_multilocation, last_junction) = location.clone().split_last_interior();
 
-			if let Some(junction) = last_junction {
-				match junction {
-					AccountId32 { .. } | AccountKey20 { .. } => true,
-					GeneralIndex(_) => {
+			let check = matches!(
+				last_junction,
+				Some(AccountId32 { .. }) |
+					Some(AccountKey20 { .. }) |
+					Some(PalletInstance(_)) |
+					None
+			);
+
+			check |
+				match last_junction {
+					Some(GeneralIndex(_)) => {
 						let penultimate = split_multilocation.last();
-						if let Some(junction) = penultimate {
-							match junction {
-								PalletInstance(_) => true,
-								_ => false,
-							}
-						} else {
-							false
-						}
+						matches!(penultimate, Some(PalletInstance(_)))
 					},
-					PalletInstance(_) => true,
 					_ => false,
 				}
-			} else {
-				false
-			}
 		}
 	}
 

--- a/pallets/asset-registry/src/lib.rs
+++ b/pallets/asset-registry/src/lib.rs
@@ -113,7 +113,10 @@ pub mod pallet {
 			);
 
 			// verify MultiLocation is valid
-			ensure!(Self::valid_location(&asset_multi_location), Error::<T>::WrongMultiLocation);
+			ensure!(
+				Self::valid_asset_location(&asset_multi_location),
+				Error::<T>::WrongMultiLocation
+			);
 
 			// register asset_id => asset_multi_location
 			AssetIdMultiLocation::<T>::insert(asset_id, &asset_multi_location);
@@ -145,7 +148,9 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
-		fn valid_location(location: &MultiLocation) -> bool {
+		//Validates that the location points to an asset (Native, Frame based, Erc20) as described
+		// in the xcm-format:  https://github.com/paritytech/xcm-format#concrete-identifiers
+		fn valid_asset_location(location: &MultiLocation) -> bool {
 			let (split_multilocation, last_junction) = location.clone().split_last_interior();
 
 			if let Some(junction) = last_junction {

--- a/pallets/asset-registry/src/tests.rs
+++ b/pallets/asset-registry/src/tests.rs
@@ -29,84 +29,167 @@ const STATEMINE_ASSET_MULTI_LOCATION: MultiLocation = MultiLocation {
 	),
 };
 
-#[test]
-fn register_reserve_asset_works() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(AssetRegistry::register_reserve_asset(
-			RuntimeOrigin::root(),
-			LOCAL_ASSET_ID,
-			STATEMINE_ASSET_MULTI_LOCATION,
-		));
+mod register_reserve_assest {
+	use super::*;
 
-		assert_eq!(
-			AssetIdMultiLocation::<Test>::get(LOCAL_ASSET_ID),
-			Some(STATEMINE_ASSET_MULTI_LOCATION)
-		);
-		assert_eq!(
-			AssetMultiLocationId::<Test>::get(STATEMINE_ASSET_MULTI_LOCATION),
-			Some(LOCAL_ASSET_ID)
-		);
-	});
-}
-
-#[test]
-fn cannot_register_unexisting_asset() {
-	new_test_ext().execute_with(|| {
-		let unexisting_asset_id = 9999;
-
-		assert_noop!(
-			AssetRegistry::register_reserve_asset(
-				RuntimeOrigin::root(),
-				unexisting_asset_id,
-				STATEMINE_ASSET_MULTI_LOCATION,
-			),
-			Error::<Test>::AssetDoesNotExist
-		);
-	});
-}
-
-#[test]
-fn cannot_double_register() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(AssetRegistry::register_reserve_asset(
-			RuntimeOrigin::root(),
-			LOCAL_ASSET_ID,
-			STATEMINE_ASSET_MULTI_LOCATION,
-		));
-
-		assert_noop!(
-			AssetRegistry::register_reserve_asset(
+	#[test]
+	fn register_reserve_asset_works() {
+		new_test_ext().execute_with(|| {
+			assert_ok!(AssetRegistry::register_reserve_asset(
 				RuntimeOrigin::root(),
 				LOCAL_ASSET_ID,
 				STATEMINE_ASSET_MULTI_LOCATION,
-			),
-			Error::<Test>::AssetAlreadyRegistered
-		);
-	});
+			));
+
+			assert_eq!(
+				AssetIdMultiLocation::<Test>::get(LOCAL_ASSET_ID),
+				Some(STATEMINE_ASSET_MULTI_LOCATION)
+			);
+			assert_eq!(
+				AssetMultiLocationId::<Test>::get(STATEMINE_ASSET_MULTI_LOCATION),
+				Some(LOCAL_ASSET_ID)
+			);
+		});
+	}
+
+	#[test]
+	fn cannot_register_unexisting_asset() {
+		new_test_ext().execute_with(|| {
+			let unexisting_asset_id = 9999;
+
+			assert_noop!(
+				AssetRegistry::register_reserve_asset(
+					RuntimeOrigin::root(),
+					unexisting_asset_id,
+					STATEMINE_ASSET_MULTI_LOCATION,
+				),
+				Error::<Test>::AssetDoesNotExist
+			);
+		});
+	}
+
+	#[test]
+	fn cannot_double_register() {
+		new_test_ext().execute_with(|| {
+			assert_ok!(AssetRegistry::register_reserve_asset(
+				RuntimeOrigin::root(),
+				LOCAL_ASSET_ID,
+				STATEMINE_ASSET_MULTI_LOCATION,
+			));
+
+			assert_noop!(
+				AssetRegistry::register_reserve_asset(
+					RuntimeOrigin::root(),
+					LOCAL_ASSET_ID,
+					STATEMINE_ASSET_MULTI_LOCATION,
+				),
+				Error::<Test>::AssetAlreadyRegistered
+			);
+		});
+	}
+
+	#[test]
+	fn valid_locations_succced() {
+		let native_frame_based_currency = MultiLocation{parents: 1, interior: X2(Parachain(1000), PalletInstance(1))};
+		let multiasset_pallet_instance = MultiLocation{parents: 1, interior: X3(Parachain(1000), PalletInstance(1), GeneralIndex(2))};
+		let erc20_frame_sm_asset = MultiLocation{parents: 1, interior: X3(Parachain(1000), PalletInstance(2), AccountId32 { network: Any, id: [0;32] })};
+		let erc20_ethereum_sm_asset = MultiLocation {parents: 1, interior: X2(Parachain(2000), AccountKey20 { network: Any, key: [0;20] })};
+		new_test_ext().execute_with(|| {
+			assert_ok!(AssetRegistry::register_reserve_asset(
+				RuntimeOrigin::root(),
+				LOCAL_ASSET_ID,
+				native_frame_based_currency,
+			));
+		});
+		new_test_ext().execute_with(|| {
+			assert_ok!(AssetRegistry::register_reserve_asset(
+				RuntimeOrigin::root(),
+				LOCAL_ASSET_ID,
+				multiasset_pallet_instance,
+			));
+		});
+		new_test_ext().execute_with(|| {
+			assert_ok!(AssetRegistry::register_reserve_asset(
+				RuntimeOrigin::root(),
+				LOCAL_ASSET_ID,
+				erc20_frame_sm_asset,
+			));
+		});
+		new_test_ext().execute_with(|| {
+			assert_ok!(AssetRegistry::register_reserve_asset(
+				RuntimeOrigin::root(),
+				LOCAL_ASSET_ID,
+				erc20_ethereum_sm_asset,
+			));
+		});
+	}
+
+	#[test]
+	fn invalid_locations_fail() {
+		let trappist_location = MultiLocation{parents: 0, interior: Here};
+		let governance_location = MultiLocation {parents: 1, interior: X2(Parachain(1000), Plurality { id: BodyId::Executive, part: BodyPart::Voice })};
+		let invalid_general_index = MultiLocation {parents: 1, interior: X2(Parachain(1000), GeneralIndex(1u128))};
+		
+		new_test_ext().execute_with(|| {
+			assert_noop!(
+				AssetRegistry::register_reserve_asset(
+					RuntimeOrigin::root(),
+					LOCAL_ASSET_ID,
+					trappist_location,
+				),
+				Error::<Test>::WrongMultiLocation
+			);
+
+			assert_noop!(
+				AssetRegistry::register_reserve_asset(
+					RuntimeOrigin::root(),
+					LOCAL_ASSET_ID,
+					governance_location,
+				),
+				Error::<Test>::WrongMultiLocation
+			);
+
+			assert_noop!(
+				AssetRegistry::register_reserve_asset(
+					RuntimeOrigin::root(),
+					LOCAL_ASSET_ID,
+					invalid_general_index,
+				),
+				Error::<Test>::WrongMultiLocation
+			);
+		})
+	}
 }
 
-#[test]
-fn unregister_reserve_asset_works() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(AssetRegistry::register_reserve_asset(
-			RuntimeOrigin::root(),
-			LOCAL_ASSET_ID,
-			STATEMINE_ASSET_MULTI_LOCATION,
-		));
+mod unregister_reserve_asset {
+	use super::*;
 
-		assert_ok!(AssetRegistry::unregister_reserve_asset(RuntimeOrigin::root(), LOCAL_ASSET_ID));
+	#[test]
+	fn unregister_reserve_asset_works() {
+		new_test_ext().execute_with(|| {
+			assert_ok!(AssetRegistry::register_reserve_asset(
+				RuntimeOrigin::root(),
+				LOCAL_ASSET_ID,
+				STATEMINE_ASSET_MULTI_LOCATION,
+			));
 
-		assert!(AssetIdMultiLocation::<Test>::get(LOCAL_ASSET_ID).is_none());
-		assert!(AssetMultiLocationId::<Test>::get(STATEMINE_ASSET_MULTI_LOCATION).is_none());
-	});
-}
+			assert_ok!(AssetRegistry::unregister_reserve_asset(
+				RuntimeOrigin::root(),
+				LOCAL_ASSET_ID
+			));
 
-#[test]
-fn cannot_register_unregistered_asset() {
-	new_test_ext().execute_with(|| {
-		assert_noop!(
-			AssetRegistry::unregister_reserve_asset(RuntimeOrigin::root(), LOCAL_ASSET_ID),
-			Error::<Test>::AssetIsNotRegistered
-		);
-	});
+			assert!(AssetIdMultiLocation::<Test>::get(LOCAL_ASSET_ID).is_none());
+			assert!(AssetMultiLocationId::<Test>::get(STATEMINE_ASSET_MULTI_LOCATION).is_none());
+		});
+	}
+
+	#[test]
+	fn cannot_register_unregistered_asset() {
+		new_test_ext().execute_with(|| {
+			assert_noop!(
+				AssetRegistry::unregister_reserve_asset(RuntimeOrigin::root(), LOCAL_ASSET_ID),
+				Error::<Test>::AssetIsNotRegistered
+			);
+		});
+	}
 }

--- a/pallets/asset-registry/src/tests.rs
+++ b/pallets/asset-registry/src/tests.rs
@@ -90,10 +90,24 @@ mod register_reserve_assest {
 
 	#[test]
 	fn valid_locations_succced() {
-		let native_frame_based_currency = MultiLocation{parents: 1, interior: X2(Parachain(1000), PalletInstance(1))};
-		let multiasset_pallet_instance = MultiLocation{parents: 1, interior: X3(Parachain(1000), PalletInstance(1), GeneralIndex(2))};
-		let erc20_frame_sm_asset = MultiLocation{parents: 1, interior: X3(Parachain(1000), PalletInstance(2), AccountId32 { network: Any, id: [0;32] })};
-		let erc20_ethereum_sm_asset = MultiLocation {parents: 1, interior: X2(Parachain(2000), AccountKey20 { network: Any, key: [0;20] })};
+		let native_frame_based_currency =
+			MultiLocation { parents: 1, interior: X2(Parachain(1000), PalletInstance(1)) };
+		let multiasset_pallet_instance = MultiLocation {
+			parents: 1,
+			interior: X3(Parachain(1000), PalletInstance(1), GeneralIndex(2)),
+		};
+		let erc20_frame_sm_asset = MultiLocation {
+			parents: 1,
+			interior: X3(
+				Parachain(1000),
+				PalletInstance(2),
+				AccountId32 { network: Any, id: [0; 32] },
+			),
+		};
+		let erc20_ethereum_sm_asset = MultiLocation {
+			parents: 1,
+			interior: X2(Parachain(2000), AccountKey20 { network: Any, key: [0; 20] }),
+		};
 		new_test_ext().execute_with(|| {
 			assert_ok!(AssetRegistry::register_reserve_asset(
 				RuntimeOrigin::root(),
@@ -126,10 +140,17 @@ mod register_reserve_assest {
 
 	#[test]
 	fn invalid_locations_fail() {
-		let trappist_location = MultiLocation{parents: 0, interior: Here};
-		let governance_location = MultiLocation {parents: 1, interior: X2(Parachain(1000), Plurality { id: BodyId::Executive, part: BodyPart::Voice })};
-		let invalid_general_index = MultiLocation {parents: 1, interior: X2(Parachain(1000), GeneralIndex(1u128))};
-		
+		let trappist_location = MultiLocation { parents: 0, interior: Here };
+		let governance_location = MultiLocation {
+			parents: 1,
+			interior: X2(
+				Parachain(1000),
+				Plurality { id: BodyId::Executive, part: BodyPart::Voice },
+			),
+		};
+		let invalid_general_index =
+			MultiLocation { parents: 1, interior: X2(Parachain(1000), GeneralIndex(1u128)) };
+
 		new_test_ext().execute_with(|| {
 			assert_noop!(
 				AssetRegistry::register_reserve_asset(

--- a/pallets/asset-registry/src/tests.rs
+++ b/pallets/asset-registry/src/tests.rs
@@ -96,6 +96,7 @@ mod register_reserve_assest {
 			parents: 1,
 			interior: X3(Parachain(1000), PalletInstance(1), GeneralIndex(2)),
 		};
+		let relay_native_currency = MultiLocation { parents: 1, interior: Junctions::Here };
 		let erc20_frame_sm_asset = MultiLocation {
 			parents: 1,
 			interior: X3(
@@ -127,6 +128,13 @@ mod register_reserve_assest {
 			assert_ok!(AssetRegistry::register_reserve_asset(
 				RuntimeOrigin::root(),
 				LOCAL_ASSET_ID,
+				relay_native_currency,
+			));
+		});
+		new_test_ext().execute_with(|| {
+			assert_ok!(AssetRegistry::register_reserve_asset(
+				RuntimeOrigin::root(),
+				LOCAL_ASSET_ID,
 				erc20_frame_sm_asset,
 			));
 		});
@@ -141,7 +149,6 @@ mod register_reserve_assest {
 
 	#[test]
 	fn invalid_locations_fail() {
-		let trappist_location = MultiLocation { parents: 0, interior: Here };
 		let governance_location = MultiLocation {
 			parents: 1,
 			interior: X2(
@@ -153,15 +160,6 @@ mod register_reserve_assest {
 			MultiLocation { parents: 1, interior: X2(Parachain(1000), GeneralIndex(1u128)) };
 
 		new_test_ext().execute_with(|| {
-			assert_noop!(
-				AssetRegistry::register_reserve_asset(
-					RuntimeOrigin::root(),
-					LOCAL_ASSET_ID,
-					trappist_location,
-				),
-				Error::<Test>::WrongMultiLocation
-			);
-
 			assert_noop!(
 				AssetRegistry::register_reserve_asset(
 					RuntimeOrigin::root(),

--- a/pallets/asset-registry/src/tests.rs
+++ b/pallets/asset-registry/src/tests.rs
@@ -108,7 +108,7 @@ mod register_reserve_assest {
 			parents: 1,
 			interior: X2(Parachain(2000), AccountKey20 { network: Any, key: [0; 20] }),
 		};
-		
+
 		new_test_ext().execute_with(|| {
 			assert_ok!(AssetRegistry::register_reserve_asset(
 				RuntimeOrigin::root(),

--- a/pallets/asset-registry/src/tests.rs
+++ b/pallets/asset-registry/src/tests.rs
@@ -108,6 +108,7 @@ mod register_reserve_assest {
 			parents: 1,
 			interior: X2(Parachain(2000), AccountKey20 { network: Any, key: [0; 20] }),
 		};
+		
 		new_test_ext().execute_with(|| {
 			assert_ok!(AssetRegistry::register_reserve_asset(
 				RuntimeOrigin::root(),


### PR DESCRIPTION
Improves the validation for the Multilocation received in `register_reserve_asset` inside the Asset-Registry pallet as discussed in #212.