### PR TITLE
Fix `pallet_xcm_benchmarks::generic::claim_asset` benchmark

### DIFF
--- a/runtime/trappist/src/lib.rs
+++ b/runtime/trappist/src/lib.rs
@@ -1065,7 +1065,7 @@ impl_runtime_apis! {
 
 				fn claimable_asset() -> Result<(MultiLocation, MultiLocation, MultiAssets), BenchmarkError> {
 					let origin = RelayLocation::get();
-					let assets: MultiAssets = (Concrete(RelayLocation::get()), 1_000 * UNITS).into();
+					let assets: MultiAssets = (Concrete(SelfReserve::get()), 1_000 * UNITS).into();
 					let ticket = MultiLocation { parents: 0, interior: Here };
 					Ok((origin, ticket, assets))
 				}


### PR DESCRIPTION
Use `SelfReserve` instead of `RelayLocation` in asset for `pallet_xcm_benchmarks::generic::claim_asset`