### PR TITLE
Fix docker image

### DIFF
--- a/docker/trappist-parachain.dockerfile
+++ b/docker/trappist-parachain.dockerfile
@@ -14,7 +14,7 @@ RUN cargo build --release
 #   --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/PEER_ID
 #
 # with the appropriate ip and ID for both Alice and Bob
-FROM debian:buster-slim as collator
+FROM debian:bullseye-slim as collator
 RUN apt-get update && apt-get install jq curl bash -y && \
     curl -sSo /wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && \
     chmod +x /wait-for-it.sh && \
@@ -33,13 +33,13 @@ HEALTHCHECK --interval=300s --timeout=75s --start-period=30s --retries=3 \
 # the runtime stage is normally built once, cached, and ignored, but can be
 # specified with the --target build flag. This just preserves one of the builder's
 # outputs, which can then be moved into a volume at runtime
-FROM debian:buster-slim as runtime
+FROM debian:bullseye-slim as runtime
 COPY --from=builder \
     /trappist/target/release/wbuild/trappist-runtime/trappist_runtime.wasm \
     /var/opt/
 CMD ["cp", "-v", "/var/opt/trappist_runtime.wasm", "/runtime/"]
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 COPY --from=builder \
     /trappist/target/release/trappist-node /usr/bin
 


### PR DESCRIPTION
Current docker image fails to start:
```
docker run -it --rm paritytech/trappist:polkadot-v0.9.37 trappist-collator  --help 
trappist-collator: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.26' not found (required by trappist-collator)
trappist-collator: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by trappist-collator)
trappist-collator: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.29' not found (required by trappist-collator)
trappist-collator: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.30' not found (required by trappist-collator)

```

## changes
1. replace docker image base