### PR TITLE
Remove lockdown mode from GenesisConfig for local

### DIFF
--- a/node/src/chain_spec/trappist.rs
+++ b/node/src/chain_spec/trappist.rs
@@ -24,7 +24,8 @@ use sc_service::ChainType;
 use sp_core::{crypto::UncheckedInto, sr25519};
 use trappist_runtime::{
 	constants::currency::EXISTENTIAL_DEPOSIT, AccountId, AssetsConfig, AuraId, BalancesConfig,
-	CouncilConfig, GenesisConfig, SessionConfig, SessionKeys, SudoConfig, SystemConfig,
+	CouncilConfig, GenesisConfig, LockdownModeConfig, SessionConfig, SessionKeys, SudoConfig,
+	SystemConfig,
 };
 
 const DEFAULT_PROTOCOL_ID: &str = "hop";
@@ -206,7 +207,7 @@ pub fn testnet_genesis(
 			phantom: Default::default(),
 		},
 		treasury: Default::default(),
-		lockdown_mode: Default::default(),
+		lockdown_mode: LockdownModeConfig { initial_status: false },
 	}
 }
 


### PR DESCRIPTION
There is no point on starting Trappist locally with the lockdown mode activated. Since it was added many users thinks the chain does not work when it's launched locally. 

For this reason, i have updated the local chain spec of Trappist to start the chain without the lockdown mode activated.