### PR TITLE
Changing XCM config for allow teleport from and to AH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11900,6 +11900,7 @@ dependencies = [
  "hex-literal",
  "kusama-runtime-constants",
  "log",
+ "pallet-asset-registry",
  "pallet-asset-tx-payment",
  "pallet-assets",
  "pallet-aura",

--- a/pallets/asset-registry/src/lib.rs
+++ b/pallets/asset-registry/src/lib.rs
@@ -112,11 +112,11 @@ pub mod pallet {
 				Error::<T>::AssetAlreadyRegistered
 			);
 
-			// verify MultiLocation is valid
-			ensure!(
-				Self::valid_asset_location(&asset_multi_location),
-				Error::<T>::WrongMultiLocation
-			);
+			// // verify MultiLocation is valid
+			// ensure!(
+			// 	Self::valid_asset_location(&asset_multi_location),
+			// 	Error::<T>::WrongMultiLocation
+			// );
 
 			// register asset_id => asset_multi_location
 			AssetIdMultiLocation::<T>::insert(asset_id, asset_multi_location);

--- a/pallets/asset-registry/src/lib.rs
+++ b/pallets/asset-registry/src/lib.rs
@@ -39,7 +39,7 @@ pub mod pallet {
 	use frame_system::pallet_prelude::*;
 
 	use xcm::latest::{
-		Junction::{AccountId32, AccountKey20, GeneralIndex, PalletInstance},
+		Junction::{AccountId32, AccountKey20, GeneralIndex, PalletInstance, Parachain},
 		MultiLocation,
 	};
 
@@ -112,11 +112,11 @@ pub mod pallet {
 				Error::<T>::AssetAlreadyRegistered
 			);
 
-			// // verify MultiLocation is valid
-			// ensure!(
-			// 	Self::valid_asset_location(&asset_multi_location),
-			// 	Error::<T>::WrongMultiLocation
-			// );
+			// verify MultiLocation is valid
+			ensure!(
+				Self::valid_asset_location(&asset_multi_location),
+				Error::<T>::WrongMultiLocation
+			);
 
 			// register asset_id => asset_multi_location
 			AssetIdMultiLocation::<T>::insert(asset_id, asset_multi_location);
@@ -158,7 +158,7 @@ pub mod pallet {
 				Some(AccountId32 { .. }) |
 					Some(AccountKey20 { .. }) |
 					Some(PalletInstance(_)) |
-					None
+					Some(Parachain(_)) | None
 			);
 
 			check |

--- a/runtime/stout/Cargo.toml
+++ b/runtime/stout/Cargo.toml
@@ -97,6 +97,7 @@ pallet-xcm-benchmarks = { workspace = true, optional = true }
 # External Pallets
 pallet-dex = { workspace = true }
 pallet-dex-rpc-runtime-api = { workspace = true }
+pallet-asset-registry = { workspace = true }
 
 [features]
 default = ["std"]

--- a/runtime/trappist/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
+++ b/runtime/trappist/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
@@ -103,7 +103,8 @@ impl<T: frame_system::Config> WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 500_000_000_000 picoseconds.
-		Weight::from_parts(500_000_000_000, 0)
+		// Extracted from previous implementations. TODO: Benchmark
+		Weight::from_parts(4_848_000, 0)
 	}
 	/// Storage: System Account (r:1 w:1)
 	/// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)

--- a/runtime/trappist/src/xcm_config.rs
+++ b/runtime/trappist/src/xcm_config.rs
@@ -331,7 +331,7 @@ impl pallet_xcm::Config for Runtime {
 	type ExecuteXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
 	type XcmExecuteFilter = Everything;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
-	type XcmTeleportFilter = Nothing;
+	type XcmTeleportFilter = Everything;
 	type XcmReserveTransferFilter = Everything;
 	type Weigher = WeightInfoBounds<
 		crate::weights::xcm::TrappistXcmWeight<RuntimeCall>,

--- a/runtime/trappist/src/xcm_config.rs
+++ b/runtime/trappist/src/xcm_config.rs
@@ -203,6 +203,7 @@ match_types! {
 	};
 }
 
+
 pub type Barrier = DenyThenTry<
 	DenyReserveTransferToRelayChain,
 	(
@@ -232,6 +233,12 @@ parameter_types! {
 	pub RocPerSecond: (xcm::v3::AssetId, u128,u128) = (MultiLocation::parent().into(), default_fee_per_second() * 70, 0u128);
 }
 
+parameter_types! {
+	pub const TrappistNative: MultiAssetFilter = Wild(AllOf { fun: WildFungible, id: Concrete(MultiLocation::here()) });
+	pub AssetHubTrustedTeleporter: (MultiAssetFilter, MultiLocation) = (TrappistNative::get(), RockmineLocation::get());
+}
+
+
 //- From PR https://github.com/paritytech/cumulus/pull/936
 fn matches_prefix(prefix: &MultiLocation, loc: &MultiLocation) -> bool {
 	prefix.parent_count() == loc.parent_count() &&
@@ -256,6 +263,7 @@ impl<T: Get<MultiLocation>> ContainsPair<MultiAsset, MultiLocation> for ReserveA
 	}
 }
 
+
 pub type Traders = (
 	// RUSD
 	FixedRateOfFungible<RUsdPerSecond, ()>,
@@ -266,6 +274,7 @@ pub type Traders = (
 );
 
 pub type Reserves = (NativeAsset, ReserveAssetsFrom<RockmineLocation>);
+pub type TrustedTeleporters = (xcm_builder::Case<AssetHubTrustedTeleporter>,);
 
 pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
@@ -274,7 +283,7 @@ impl xcm_executor::Config for XcmConfig {
 	type AssetTransactor = AssetTransactors;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	type IsReserve = Reserves;
-	type IsTeleporter = Everything;
+	type IsTeleporter = TrustedTeleporters;
 	type UniversalLocation = UniversalLocation;
 	type Barrier = Barrier;
 	type Weigher = WeightInfoBounds<

--- a/runtime/trappist/src/xcm_config.rs
+++ b/runtime/trappist/src/xcm_config.rs
@@ -260,23 +260,14 @@ impl<T: Get<MultiLocation>> ContainsPair<MultiAsset, MultiLocation> for ReserveA
 pub struct OnlyTeleportNative;
 impl Contains<(MultiLocation, Vec<MultiAsset>)> for OnlyTeleportNative {
 	fn contains(t: &(MultiLocation, Vec<MultiAsset>)) -> bool {
-t.1.iter().any(|asset| {
-    log::trace!(target: "xcm::OnlyTeleportNative", "Asset to be teleported: {:?}", asset);
-    match asset {
-        MultiAsset { id: xcm::latest::AssetId::Concrete(asset_loc), fun: Fungible(_a) } =>
-            matches_prefix(&SelfReserve::get(), asset_loc),
-        _ => false,
-    }
-})
-			return false
-		}
-		let asset = &t.1[0];
-		log::trace!(target: "xcm::OnlyTeleportNative", "Asset to be teleported: {:?}", asset);
-		match asset {
-			MultiAsset { id: xcm::latest::AssetId::Concrete(asset_loc), fun: Fungible(_a) } =>
-				matches_prefix(&SelfReserve::get(), asset_loc),
-			_ => false,
-		}
+		t.1.iter().any(|asset| {
+			log::trace!(target: "xcm::OnlyTeleportNative", "Asset to be teleported: {:?}", asset);
+			match asset {
+				MultiAsset { id: xcm::latest::AssetId::Concrete(asset_loc), fun: Fungible(_a) } =>
+					matches_prefix(&SelfReserve::get(), asset_loc),
+				_ => false,
+			}
+		})
 	}
 }
 

--- a/runtime/trappist/src/xcm_config.rs
+++ b/runtime/trappist/src/xcm_config.rs
@@ -251,13 +251,14 @@ pub struct ReserveAssetsFrom<T>(PhantomData<T>);
 impl<T: Get<MultiLocation>> ContainsPair<MultiAsset, MultiLocation> for ReserveAssetsFrom<T> {
 	fn contains(asset: &MultiAsset, origin: &MultiLocation) -> bool {
 		let prefix = T::get();
-		log::trace!(target: "xcm::AssetsFrom", "prefix: {:?}, origin: {:?}", prefix, origin);
-		&prefix == origin &&
-			match asset {
-				MultiAsset { id: xcm::latest::AssetId::Concrete(asset_loc), fun: Fungible(_a) } =>
-					matches_prefix(&prefix, asset_loc),
-				_ => false,
-			}
+		log::trace!(target: "xcm::AssetsFrom", "prefix: {:?}, origin: {:?}, asset: {:?}", prefix, origin, asset);
+		&prefix == origin 
+		// &&
+		// 	match asset {
+		// 		MultiAsset { id: xcm::latest::AssetId::Concrete(asset_loc), fun: Fungible(_a) } =>
+		// 			matches_prefix(&prefix, asset_loc),
+		// 		_ => false,
+		// 	}
 	}
 }
 

--- a/runtime/trappist/src/xcm_config.rs
+++ b/runtime/trappist/src/xcm_config.rs
@@ -153,7 +153,7 @@ pub type ReservedFungiblesTransactor = FungiblesAdapter<
 
 /// Means for transacting assets on this chain.
 pub type AssetTransactors =
-	(LocalAssetTransactor, ReservedFungiblesTransactor/* , LocalFungiblesTransactor*/);
+	(LocalAssetTransactor, ReservedFungiblesTransactor /* , LocalFungiblesTransactor */);
 
 /// This is the type we use to convert an (incoming) XCM origin into a local `Origin` instance,
 /// ready for dispatching a transaction with Xcm's `Transact`. There is an `OriginKind` which can

--- a/runtime/trappist/src/xcm_config.rs
+++ b/runtime/trappist/src/xcm_config.rs
@@ -153,9 +153,8 @@ pub type ReservedFungiblesTransactor = FungiblesAdapter<
 >;
 
 /// Means for transacting assets on this chain.
-/// TODO: Is LocalFungiblesTransactor needed?
 pub type AssetTransactors =
-	(LocalAssetTransactor, ReservedFungiblesTransactor /* , LocalFungiblesTransactor */);
+	(LocalAssetTransactor, ReservedFungiblesTransactor, LocalFungiblesTransactor);
 
 /// This is the type we use to convert an (incoming) XCM origin into a local `Origin` instance,
 /// ready for dispatching a transaction with Xcm's `Transact`. There is an `OriginKind` which can
@@ -232,11 +231,6 @@ parameter_types! {
 	);
 	/// Roc = 7 RUSD
 	pub RocPerSecond: (xcm::v3::AssetId, u128,u128) = (MultiLocation::parent().into(), default_fee_per_second() * 70, 0u128);
-	// TODO: How to define this ratio?
-	pub MockTokenPerSecond: (xcm::v3::AssetId, u128, u128) = (
-		MultiLocation::new(1, X3(Parachain(1000), PalletInstance(50), GeneralIndex(10))).into(),
-		default_fee_per_second() * 1,
-		0u128);
 }
 
 parameter_types! {
@@ -260,14 +254,6 @@ impl<T: Get<MultiLocation>> ContainsPair<MultiAsset, MultiLocation> for ReserveA
 		let prefix = T::get();
 		log::trace!(target: "xcm::AssetsFrom", "prefix: {:?}, origin: {:?}, asset: {:?}", prefix, origin, asset);
 		&prefix == origin
-		// TODO: Check on how to fix assetId location as in foreign assets this does not apply.
-		// Assets being sent from AH but asset_loc is another parachain.
-		//	&&
-		// 	match asset {
-		// 		MultiAsset { id: xcm::latest::AssetId::Concrete(asset_loc), fun: Fungible(_a) } =>
-		// 			matches_prefix(&prefix, asset_loc),
-		// 		_ => false,
-		// 	}
 	}
 }
 
@@ -292,8 +278,6 @@ pub type Traders = (
 	FixedRateOfFungible<RUsdPerSecond, ()>,
 	// Roc
 	FixedRateOfFungible<RocPerSecond, ()>,
-	//Mock Token
-	FixedRateOfFungible<MockTokenPerSecond, ()>,
 	// Everything else
 	UsingComponents<WeightToFee, SelfReserve, AccountId, Balances, ToAuthor<Runtime>>,
 );

--- a/runtime/trappist/src/xcm_config.rs
+++ b/runtime/trappist/src/xcm_config.rs
@@ -153,7 +153,7 @@ pub type ReservedFungiblesTransactor = FungiblesAdapter<
 
 /// Means for transacting assets on this chain.
 pub type AssetTransactors =
-	(LocalAssetTransactor, ReservedFungiblesTransactor, LocalFungiblesTransactor);
+	(LocalAssetTransactor, ReservedFungiblesTransactor/* , LocalFungiblesTransactor*/);
 
 /// This is the type we use to convert an (incoming) XCM origin into a local `Origin` instance,
 /// ready for dispatching a transaction with Xcm's `Transact`. There is an `OriginKind` which can
@@ -230,6 +230,7 @@ parameter_types! {
 	);
 	/// Roc = 7 RUSD
 	pub RocPerSecond: (xcm::v3::AssetId, u128,u128) = (MultiLocation::parent().into(), default_fee_per_second() * 70, 0u128);
+	pub MockTokenPerSecond: (xcm::v3::AssetId, u128, u128) = (MultiLocation::new(1, X3(Parachain(1000), PalletInstance(50), GeneralIndex(10))).into(), default_fee_per_second() * 1, 0u128);
 }
 
 parameter_types! {
@@ -267,6 +268,8 @@ pub type Traders = (
 	FixedRateOfFungible<RUsdPerSecond, ()>,
 	// Roc
 	FixedRateOfFungible<RocPerSecond, ()>,
+	//Mock Token
+	FixedRateOfFungible<MockTokenPerSecond, ()>,
 	// Everything else
 	UsingComponents<WeightToFee, SelfReserve, AccountId, Balances, ToAuthor<Runtime>>,
 );

--- a/runtime/trappist/src/xcm_config.rs
+++ b/runtime/trappist/src/xcm_config.rs
@@ -273,9 +273,8 @@ impl xcm_executor::Config for XcmConfig {
 	type AssetTransactor = AssetTransactors;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	type IsReserve = Reserves;
-	type IsTeleporter = ();
+	type IsTeleporter = Everything;
 	type UniversalLocation = UniversalLocation;
-	// Teleporting is disabled.
 	type Barrier = Barrier;
 	type Weigher = WeightInfoBounds<
 		crate::weights::xcm::TrappistXcmWeight<RuntimeCall>,

--- a/runtime/trappist/src/xcm_config.rs
+++ b/runtime/trappist/src/xcm_config.rs
@@ -203,7 +203,6 @@ match_types! {
 	};
 }
 
-
 pub type Barrier = DenyThenTry<
 	DenyReserveTransferToRelayChain,
 	(
@@ -238,7 +237,6 @@ parameter_types! {
 	pub AssetHubTrustedTeleporter: (MultiAssetFilter, MultiLocation) = (TrappistNative::get(), RockmineLocation::get());
 }
 
-
 //- From PR https://github.com/paritytech/cumulus/pull/936
 fn matches_prefix(prefix: &MultiLocation, loc: &MultiLocation) -> bool {
 	prefix.parent_count() == loc.parent_count() &&
@@ -262,7 +260,6 @@ impl<T: Get<MultiLocation>> ContainsPair<MultiAsset, MultiLocation> for ReserveA
 			}
 	}
 }
-
 
 pub type Traders = (
 	// RUSD

--- a/runtime/trappist/src/xcm_config.rs
+++ b/runtime/trappist/src/xcm_config.rs
@@ -260,7 +260,14 @@ impl<T: Get<MultiLocation>> ContainsPair<MultiAsset, MultiLocation> for ReserveA
 pub struct OnlyTeleportNative;
 impl Contains<(MultiLocation, Vec<MultiAsset>)> for OnlyTeleportNative {
 	fn contains(t: &(MultiLocation, Vec<MultiAsset>)) -> bool {
-		if t.1.len() != 1 {
+t.1.iter().any(|asset| {
+    log::trace!(target: "xcm::OnlyTeleportNative", "Asset to be teleported: {:?}", asset);
+    match asset {
+        MultiAsset { id: xcm::latest::AssetId::Concrete(asset_loc), fun: Fungible(_a) } =>
+            matches_prefix(&SelfReserve::get(), asset_loc),
+        _ => false,
+    }
+})
 			return false
 		}
 		let asset = &t.1[0];

--- a/runtime/trappist/src/xcm_config.rs
+++ b/runtime/trappist/src/xcm_config.rs
@@ -106,7 +106,7 @@ pub type LocalAssetTransactor = CurrencyAdapter<
 	LocationToAccountId,
 	// Our chain's account ID type (we can't get away without mentioning it explicitly):
 	AccountId,
-  // We don't track any teleports.
+	// We don't track any teleports.
 	(),
 >;
 
@@ -252,7 +252,7 @@ impl<T: Get<MultiLocation>> ContainsPair<MultiAsset, MultiLocation> for ReserveA
 	fn contains(asset: &MultiAsset, origin: &MultiLocation) -> bool {
 		let prefix = T::get();
 		log::trace!(target: "xcm::AssetsFrom", "prefix: {:?}, origin: {:?}, asset: {:?}", prefix, origin, asset);
-		&prefix == origin 
+		&prefix == origin
 		// &&
 		// 	match asset {
 		// 		MultiAsset { id: xcm::latest::AssetId::Concrete(asset_loc), fun: Fungible(_a) } =>

--- a/runtime/trappist/src/xcm_config.rs
+++ b/runtime/trappist/src/xcm_config.rs
@@ -63,6 +63,7 @@ parameter_types! {
 	pub SelfReserve: MultiLocation = MultiLocation { parents:0, interior: Here };
 	pub AssetsPalletLocation: MultiLocation =
 		PalletInstance(<Assets as PalletInfoAccess>::index() as u8).into();
+	// Be mindful with incoming teleports if you implement this
 	pub CheckAccount: (AccountId, MintLocation) = (PolkadotXcm::check_account(), MintLocation::Local);
 	pub PlaceholderAccount: AccountId = PolkadotXcm::check_account();
 	pub const ExecutiveBody: BodyId = BodyId::Executive;
@@ -105,8 +106,8 @@ pub type LocalAssetTransactor = CurrencyAdapter<
 	LocationToAccountId,
 	// Our chain's account ID type (we can't get away without mentioning it explicitly):
 	AccountId,
-	// We keep track of in/out teleports. (Needed to teleport HOP to AH)
-	CheckAccount,
+	// We don't track any teleports.
+	(),
 >;
 
 /// Means for transacting assets besides the native currency on this chain.


### PR DESCRIPTION
Basic changes that need to be implemented for allowing teleporting from and to AH from Trappist. Remove filter, add AH as trusted teleporter and fix Currency adapter.