### PR TITLE
Fix benchmark TrustedTeleporter

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  POLKA_VERSION: 0.9.43
+  POLKA_VERSION: 1.0.0
 
 jobs:
   lint:

--- a/runtime/trappist/src/lib.rs
+++ b/runtime/trappist/src/lib.rs
@@ -1102,7 +1102,7 @@ impl_runtime_apis! {
 			impl cumulus_pallet_session_benchmarking::Config for Runtime {}
 
 			use xcm::latest::prelude::*;
-			use xcm_config::{RelayLocation, SelfReserve};
+			use xcm_config::{RelayLocation, SelfReserve, RockmineLocation};
 			use pallet_xcm_benchmarks::asset_instance_from;
 
 			impl pallet_xcm_benchmarks::Config for Runtime {
@@ -1139,9 +1139,9 @@ impl_runtime_apis! {
 			}
 
 			parameter_types! {
-				pub const TrustedTeleporter: Option<(MultiLocation, MultiAsset)> = Some((
-					RelayLocation::get(),
-					MultiAsset { fun: Fungible(1 * UNITS), id: Concrete(RelayLocation::get()) },
+				pub TrustedTeleporter: Option<(MultiLocation, MultiAsset)> = Some((
+					RockmineLocation::get(),
+					MultiAsset { fun: Fungible(1 * UNITS), id: Concrete(SelfReserve::get()) },
 				));
 				pub const CheckedAccount: Option<(AccountId, xcm_builder::MintLocation)> = None;
 


### PR DESCRIPTION
`ReceiveTeleportedAsset` was having `MAX_BLOCK` weight due to benchmark `TrustedTeleported` not matching the one from the runtime.