### PR TITLE
ci: limit disk usage

### DIFF
--- a/.github/templates/setup-worker/action.yaml
+++ b/.github/templates/setup-worker/action.yaml
@@ -10,10 +10,3 @@ runs:
     - name: Setup Ubuntu dependencies
       shell: bash
       run: sudo apt update && sudo apt install -y git clang curl libssl-dev llvm libudev-dev cmake protobuf-compiler
-
-    - name: Install Rust nightly
-      shell: bash
-      run: |
-        rustup toolchain install nightly-2023-01-01 --profile minimal --component rustfmt
-        rustup default nightly-2023-01-01
-        rustup target add wasm32-unknown-unknown

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,6 +11,7 @@ on:
   workflow_dispatch:
 
 env:
+  CARGO_INCREMENTAL: 0
   POLKA_VERSION: 1.0.0
 
 jobs:
@@ -35,16 +36,11 @@ jobs:
         uses: "./.github/templates/setup-worker"
 
       - name: Cache Build artefacts
-        uses: actions/cache@v3
+        uses: Swatinem/rust-cache@v2.7.0
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-release-${{ env.POLKA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-release-${{ env.POLKA_VERSION }}
+          cache-on-failure: true
+          shared-key: ${{ env.POLKA_VERSION }}
+          key: "release"
 
       - name: Check Build Trappist node
         run: |
@@ -64,16 +60,11 @@ jobs:
         uses: "./.github/templates/setup-worker"
 
       - name: Cache Build artefacts
-        uses: actions/cache@v3
+        uses: Swatinem/rust-cache@v2.7.0
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-debug-${{ env.POLKA_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-debug-${{ env.POLKA_VERSION }}
+          cache-on-failure: true
+          shared-key: ${{ env.POLKA_VERSION }}
+          key: "debug"
 
       - name: Run Trappist tests
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,8 +39,7 @@ jobs:
         uses: Swatinem/rust-cache@v2.7.0
         with:
           cache-on-failure: true
-          shared-key: ${{ env.POLKA_VERSION }}
-          key: "release"
+          shared-key: ${{ env.POLKA_VERSION }}-release
 
       - name: Check Build Trappist node
         run: |
@@ -63,8 +62,7 @@ jobs:
         uses: Swatinem/rust-cache@v2.7.0
         with:
           cache-on-failure: true
-          shared-key: ${{ env.POLKA_VERSION }}
-          key: "debug"
+          shared-key: ${{ env.POLKA_VERSION }}-debug
 
       - name: Run Trappist tests
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ inherits = "release"
 lto = true
 codegen-units = 1
 
+[profile.test]
+debug = 0
+
 [workspace.package]
 authors = ["Trappist Network <https://github.com/TrappistNetwork>"]
 homepage = "https://trappist.io"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 exclude = [
 	"xcm-simulator"
 ]
+resolver = "2"
 
 [profile.release]
 panic = "unwind"


### PR DESCRIPTION
A few attempts to limit the disk usage during CI tests:
- Sets the default resolver for the virtual workspace as per https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html, mostly to silence the build warnings:
```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```
- disables debug info for the test profile (debatable on whether this should be done)
- removes nightly from the setup-worker template
- uses Swatinem/rust-cache for 'smart rust caching', along with disabling incremental builds.

Based on suggestions from https://matklad.github.io/2021/09/04/fast-rust-builds.html#CI-Caching and https://matklad.github.io/2021/09/04/fast-rust-builds.html#CI-Workflow.

PS - [caches](https://github.com/paritytech/trappist/actions/caches) are now 1.1gb (release) and 1.5gb (debug), whereas previously the debug cache was ~4.5gb.