### PR TITLE
feat: update `pallet-uniques` string limits. #297

### DIFF
--- a/runtime/stout/src/lib.rs
+++ b/runtime/stout/src/lib.rs
@@ -439,9 +439,9 @@ parameter_types! {
 	pub const DepositPerByte: Balance = deposit(0, 1);
 	pub const CollectionDeposit: Balance = 100 * UNITS;
 	pub const ItemDeposit: Balance = 1 * UNITS;
-	pub const StringLimit: u32 = 50;
+	pub const StringLimit: u32 = 128;
 	pub const KeyLimit: u32 = 32;
-	pub const ValueLimit: u32 = 256;
+	pub const ValueLimit: u32 = 64;
 }
 
 impl pallet_uniques::Config for Runtime {

--- a/runtime/trappist/src/lib.rs
+++ b/runtime/trappist/src/lib.rs
@@ -442,9 +442,9 @@ parameter_types! {
 	pub const DepositPerByte: Balance = deposit(0, 1);
 	pub const CollectionDeposit: Balance = 100 * UNITS;
 	pub const ItemDeposit: Balance = 1 * UNITS;
-	pub const StringLimit: u32 = 50;
+	pub const StringLimit: u32 = 128;
 	pub const KeyLimit: u32 = 32;
-	pub const ValueLimit: u32 = 256;
+	pub const ValueLimit: u32 = 64;
 }
 
 impl pallet_uniques::Config for Runtime {


### PR DESCRIPTION
See the following for more details: https://github.com/paritytech/trappist/issues/297.

Update the `pallet-uniques` string limits to match Polkadot's Asset hub. 

https://github.com/paritytech/polkadot-sdk/blob/master/cumulus/parachains/runtimes/assets/asset-hub-polkadot/src/lib.rs#L683
```
	pub const StringLimit: u32 = 128;
	pub const KeyLimit: u32 = 32;
	pub const ValueLimit: u32 = 64;
```