### PR TITLE
fix: stout runtime zombienet config

### DIFF
--- a/zombienet/stout_rococo.toml
+++ b/zombienet/stout_rococo.toml
@@ -78,15 +78,3 @@ sender = 3000
 recipient = 1000
 max_capacity = 8
 max_message_size = 512
-
-[[hrmp_channels]]
-sender = 1836
-recipient = 3000
-max_capacity = 8
-max_message_size = 512
-
-[[hrmp_channels]]
-sender = 3000
-recipient = 1836
-max_capacity = 8
-max_message_size = 512


### PR DESCRIPTION
The zombienet config for the stout runtime would cause the zombienet startup to fail. This is because it attempted to open HRMP channels with the non-existent Trappist chain (id 1836).

The solution is to remove the attempted HRMP channels as the `full_network` config is for stout + trappist. 