### PR TITLE
Bump rust version in dockerfile for collator image

### DIFF
--- a/docker/trappist-parachain.dockerfile
+++ b/docker/trappist-parachain.dockerfile
@@ -1,5 +1,5 @@
 # This file is sourced from https://github.com/paritytech/polkadot-sdk/blob/master/scripts/ci/dockerfiles/polkadot/polkadot_builder.Dockerfile
-FROM docker.io/paritytech/ci-linux:1.68.2-bullseye as builder
+FROM docker.io/paritytech/ci-linux:1.71.0-bullseye as builder
 
 WORKDIR /trappist
 COPY . /trappist


### PR DESCRIPTION
Last run to build the collator image for Trappist v1.1.0 [failed](https://github.com/paritytech/trappist/actions/runs/6985009825/job/19008681490#step:5:1086) because the Rust version used is too old (v1.68.2).