### PR TITLE
HRMP Workaround and Zombienet chores

### DIFF
--- a/node/src/chain_spec/trappist.rs
+++ b/node/src/chain_spec/trappist.rs
@@ -137,7 +137,7 @@ pub fn trappist_local_testnet_config() -> ChainSpec {
 			)
 		},
 		// Bootnodes
-		vec![],
+		Vec::new(),
 		// Telemetry
 		None,
 		// Protocol ID

--- a/scripts/hrmp_helper.sh
+++ b/scripts/hrmp_helper.sh
@@ -1,0 +1,103 @@
+# Helper script to open HRMP channels between Trappist, Stout and Asset Hub. 
+# This script is meant to be run after the relay chain and parachains are spawned.
+
+# Change for your bin path
+POLKADOT_BIN=~/projects/trappist/bin/polkadot
+POLKADOT_PARACHAIN_BIN=~/projects/trappist/bin/polkadot-parachain
+
+function ensure_binaries() {
+    echo "*** Checking for required binaries"
+    if [[ ! -f "$POLKADOT_BIN" ]]; then
+        echo "  Required polkadot binary '$POLKADOT_BIN' does not exist!"
+        echo "  You need to build it and copy to this location!"
+        exit 1
+    fi
+    if [[ ! -f "$POLKADOT_PARACHAIN_BIN" ]]; then
+        echo "  Required polkadot-parachain binary '$POLKADOT_PARACHAIN_BIN' does not exist!"
+        echo "  You need to build it and copy to this location!"
+        exit 1
+    fi
+    echo "*** All required binaries are present"
+}
+
+function ensure_polkadot_js_api() {
+    echo "*** Checking for required polkadot-js-api"
+    if ! which polkadot-js-api &>/dev/null; then
+        echo ''
+        echo 'Required command `polkadot-js-api` not in PATH, please, install, e.g.:'
+        echo "npm install -g @polkadot/api-cli"
+        echo "      or"
+        echo "yarn global add @polkadot/api-cli"
+        echo ''
+        exit 1
+    fi
+}
+
+function open_hrmp_channels() {
+    local relay_url=$1
+    local relay_chain_seed=$2
+    local sender_para_id=$3
+    local recipient_para_id=$4
+    local max_capacity=$5
+    local max_message_size=$6
+    echo "  calling open_hrmp_channels:"
+    echo "      relay_url: ${relay_url}"
+    echo "      relay_chain_seed: ${relay_chain_seed}"
+    echo "      sender_para_id: ${sender_para_id}"
+    echo "      recipient_para_id: ${recipient_para_id}"
+    echo "      max_capacity: ${max_capacity}"
+    echo "      max_message_size: ${max_message_size}"
+    echo "      params:"
+    echo "--------------------------------------------------"
+    polkadot-js-api \
+        --ws "${relay_url?}" \
+        --seed "${relay_chain_seed?}" \
+        --sudo \
+        tx.hrmp.forceOpenHrmpChannel \
+        ${sender_para_id} \
+        ${recipient_para_id} \
+        ${max_capacity} \
+        ${max_message_size}
+}
+
+# Check for binaries
+ensure_binaries
+
+# Check for polkadot-js-api cli
+ensure_polkadot_js_api
+
+# HRMP: Trappist - Stout
+open_hrmp_channels \
+    "ws://127.0.0.1:9900" \
+    "//Alice" \
+    1836 3000 4 524288
+
+# HRMP: Stout - Trappist
+open_hrmp_channels \
+    "ws://127.0.0.1:9900" \
+    "//Alice" \
+    3000 1836 4 524288
+
+# HRMP: Trappist - Asset Hub
+open_hrmp_channels \
+    "ws://127.0.0.1:9900" \
+    "//Alice" \
+    1836 1000 4 524288
+
+# HRMP: Asset Hub - Trappist
+open_hrmp_channels \
+    "ws://127.0.0.1:9900" \
+    "//Alice" \
+    1000 1836 4 524288
+
+# HRMP: Stout - Asset Hub
+open_hrmp_channels \
+    "ws://127.0.0.1:9900" \
+    "//Alice" \
+    3000 1000 4 524288
+
+# HRMP: Asset Hub - Stout
+open_hrmp_channels \
+    "ws://127.0.0.1:9900" \
+    "//Alice" \
+    1000 3000 4 524288

--- a/zombienet/full_network.toml
+++ b/zombienet/full_network.toml
@@ -5,26 +5,26 @@ timeout = 1000
 chain = "rococo-local"
 default_command = "./bin/polkadot"
 
-  [[relaychain.nodes]]
-  name = "alice"
-  validator = true
-  ws_port = 9900
-  extra_args = [ "-lparachain=debug" ]
+[[relaychain.nodes]]
+name = "alice"
+validator = true
+ws_port = 9900
+extra_args = ["-lparachain=debug"]
 
-  [[relaychain.nodes]]
-  name = "bob"
-  validator = true
-  extra_args = [ "-lparachain=debug" ]
+[[relaychain.nodes]]
+name = "bob"
+validator = true
+extra_args = ["-lparachain=debug"]
 
-  [[relaychain.nodes]]
-  name = "charlie"
-  validator = true
-  extra_args = [ "-lparachain=debug" ]
+[[relaychain.nodes]]
+name = "charlie"
+validator = true
+extra_args = ["-lparachain=debug"]
 
-  [[relaychain.nodes]]
-  name = "dave"
-  validator = true
-  extra_args = [ "-lparachain=debug" ]
+[[relaychain.nodes]]
+name = "dave"
+validator = true
+extra_args = ["-lparachain=debug"]
 
 [[parachains]]
 id = 1000
@@ -32,17 +32,17 @@ add_to_genesis = true
 cumulus_based = true
 chain = "asset-hub-rococo-local"
 
-  [[parachains.collators]]
-  name = "asset-hub-collator01"
-  command = "./bin/polkadot-parachain"
-  ws_port = 9910
-  args = ["--log=xcm=trace,pallet-assets=trace"]
+[[parachains.collators]]
+name = "asset-hub-collator01"
+command = "./bin/polkadot-parachain"
+ws_port = 9910
+args = ["--log=xcm=trace,pallet-assets=trace"]
 
-  [[parachains.collators]]
-  name = "asset-hub-collator02"
-  command = "./bin/polkadot-parachain"
-  ws_port = 9911
-  args = ["--log=xcm=trace,pallet-assets=trace"]
+[[parachains.collators]]
+name = "asset-hub-collator02"
+command = "./bin/polkadot-parachain"
+ws_port = 9911
+args = ["--log=xcm=trace,pallet-assets=trace"]
 
 [[parachains]]
 id = 1836
@@ -50,17 +50,17 @@ add_to_genesis = true
 cumulus_based = true
 chain = "trappist-local"
 
-  [[parachains.collators]]
-  name = "trappist-collator01"
-  command = "./target/release/trappist-node"
-  ws_port = 9920
-  args = ["--log=xcm=trace,pallet-assets=trace"]
+[[parachains.collators]]
+name = "trappist-collator01"
+command = "./target/release/trappist-node"
+ws_port = 9920
+args = ["--log=xcm=trace,pallet-assets=trace"]
 
-  [[parachains.collators]]
-  name = "trappist-collator02"
-  command = "./target/release/trappist-node"
-  ws_port = 9921
-  args = ["--log=xcm=trace,pallet-assets=trace"]
+[[parachains.collators]]
+name = "trappist-collator02"
+command = "./target/release/trappist-node"
+ws_port = 9921
+args = ["--log=xcm=trace,pallet-assets=trace"]
 
 [[parachains]]
 id = 3000
@@ -68,25 +68,26 @@ add_to_genesis = true
 cumulus_based = true
 chain = "stout-local"
 
-  [[parachains.collators]]
-  name = "stout-collator01"
-  command = "./target/release/trappist-node"
-  ws_port = 9930
-  args = ["--log=xcm=trace,pallet-assets=trace"]
+[[parachains.collators]]
+name = "stout-collator01"
+command = "./target/release/trappist-node"
+ws_port = 9930
+args = ["--log=xcm=trace,pallet-assets=trace"]
 
-  [[parachains.collators]]
-  name = "stout-collator02"
-  command = "./target/release/trappist-node"
-  ws_port = 9931
-  args = ["--log=xcm=trace,pallet-assets=trace"]
+[[parachains.collators]]
+name = "stout-collator02"
+command = "./target/release/trappist-node"
+ws_port = 9931
+args = ["--log=xcm=trace,pallet-assets=trace"]
 
 [types.Header]
 number = "u64"
 parent_hash = "Hash"
 post_state = "Hash"
 
-# Currently there is a known issue with opening hrmp channels on Zombienete config. 
-# Use hrmp_helper to open channels instead.
+# Currently there is a known issue with opening hrmp channels 
+# on genesis that stops block production after epoch 1. 
+# Use hrmp_helper script after network spawn to open channels instead.
 
 # [[hrmp_channels]]
 # sender = 1000

--- a/zombienet/stout_rococo.toml
+++ b/zombienet/stout_rococo.toml
@@ -67,14 +67,18 @@ number = "u64"
 parent_hash = "Hash"
 post_state = "Hash"
 
-[[hrmp_channels]]
-sender = 1000
-recipient = 3000
-max_capacity = 8
-max_message_size = 512
+# Currently there is a known issue with opening hrmp channels 
+# on genesis that stops block production after epoch 1. 
+# Use hrmp_helper script after network spawn to open channels instead.
 
-[[hrmp_channels]]
-sender = 3000
-recipient = 1000
-max_capacity = 8
-max_message_size = 512
+# [[hrmp_channels]]
+# sender = 1000
+# recipient = 3000
+# max_capacity = 8
+# max_message_size = 512
+
+# [[hrmp_channels]]
+# sender = 3000
+# recipient = 1000
+# max_capacity = 8
+# max_message_size = 512

--- a/zombienet/trappist_rococo.toml
+++ b/zombienet/trappist_rococo.toml
@@ -67,14 +67,18 @@ number = "u64"
 parent_hash = "Hash"
 post_state = "Hash"
 
-[[hrmp_channels]]
-sender = 1000
-recipient = 1836
-max_capacity = 8
-max_message_size = 512
+# Currently there is a known issue with opening hrmp channels 
+# on genesis that stops block production after epoch 1. 
+# Use hrmp_helper script after network spawn to open channels instead.
 
-[[hrmp_channels]]
-sender = 1836
-recipient = 1000
-max_capacity = 8
-max_message_size = 512
+# [[hrmp_channels]]
+# sender = 1000
+# recipient = 1836
+# max_capacity = 8
+# max_message_size = 512
+
+# [[hrmp_channels]]
+# sender = 1836
+# recipient = 1000
+# max_capacity = 8
+# max_message_size = 512

--- a/zombienet/trappist_stout.toml
+++ b/zombienet/trappist_stout.toml
@@ -4,6 +4,7 @@ timeout = 1000
 [relaychain]
 chain = "rococo-local"
 default_command = "./bin/polkadot"
+# chain_spec_path = "./bin/rococo-local-plain-custom.json"
 
   [[relaychain.nodes]]
   name = "alice"
@@ -25,24 +26,6 @@ default_command = "./bin/polkadot"
   name = "dave"
   validator = true
   extra_args = [ "-lparachain=debug" ]
-
-[[parachains]]
-id = 1000
-add_to_genesis = true
-cumulus_based = true
-chain = "asset-hub-rococo-local"
-
-  [[parachains.collators]]
-  name = "asset-hub-collator01"
-  command = "./bin/polkadot-parachain"
-  ws_port = 9910
-  args = ["--log=xcm=trace,pallet-assets=trace"]
-
-  [[parachains.collators]]
-  name = "asset-hub-collator02"
-  command = "./bin/polkadot-parachain"
-  ws_port = 9911
-  args = ["--log=xcm=trace,pallet-assets=trace"]
 
 [[parachains]]
 id = 1836
@@ -87,30 +70,6 @@ post_state = "Hash"
 
 # Currently there is a known issue with opening hrmp channels on Zombienete config. 
 # Use hrmp_helper to open channels instead.
-
-# [[hrmp_channels]]
-# sender = 1000
-# recipient = 1836
-# max_capacity = 8
-# max_message_size = 512
-
-# [[hrmp_channels]]
-# sender = 1836
-# recipient = 1000
-# max_capacity = 8
-# max_message_size = 512
-
-# [[hrmp_channels]]
-# sender = 1000
-# recipient = 3000
-# max_capacity = 8
-# max_message_size = 512
-
-# [[hrmp_channels]]
-# sender = 3000
-# recipient = 1000
-# max_capacity = 8
-# max_message_size = 512
 
 # [[hrmp_channels]]
 # sender = 1836

--- a/zombienet/trappist_stout.toml
+++ b/zombienet/trappist_stout.toml
@@ -68,8 +68,9 @@ number = "u64"
 parent_hash = "Hash"
 post_state = "Hash"
 
-# Currently there is a known issue with opening hrmp channels on Zombienete config. 
-# Use hrmp_helper to open channels instead.
+# Currently there is a known issue with opening hrmp channels 
+# on genesis that stops block production after epoch 1. 
+# Use hrmp_helper script after network spawn to open channels instead.
 
 # [[hrmp_channels]]
 # sender = 1836


### PR DESCRIPTION
Due to current [issue](https://github.com/paritytech/polkadot-sdk/pull/1616) on genesis pre open, we comment out HRMP channels from zombienet config and create a helper script to spin up hrmp channels after zombienet spawn. 