### PR TITLE
Asset Hub - Stout NFT transfers

### DIFF
--- a/runtime/stout/src/lib.rs
+++ b/runtime/stout/src/lib.rs
@@ -467,10 +467,13 @@ parameter_types! {
 	pub const ValueLimit: u32 = 64;
 }
 
+type StoutCollectionId = u32;
+type StoutItemId = u32;
+
 impl pallet_uniques::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type CollectionId = u32;
-	type ItemId = u32;
+	type CollectionId = StoutCollectionId;
+	type ItemId = StoutItemId;
 	type Currency = Balances;
 	type ForceOrigin = frame_system::EnsureRoot<AccountId>;
 	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;

--- a/zombienet/stout_rococo.toml
+++ b/zombienet/stout_rococo.toml
@@ -30,19 +30,19 @@ default_command = "./bin/polkadot"
 id = 1000
 add_to_genesis = true
 cumulus_based = true
-chain = "statemine-local"
+chain = "asset-hub-rococo-local"
 
   [[parachains.collators]]
   name = "statemine-collator01"
   command = "./bin/polkadot-parachain"
   ws_port = 9910
-  args = ["--log=xcm=trace,pallet-assets=trace"]
+  args = ["--log=xcm=trace,pallet-assets=trace,pallet-uniques=trace"]
 
   [[parachains.collators]]
   name = "statemine-collator02"
   command = "./bin/polkadot-parachain"
   ws_port = 9911
-  args = ["--log=xcm=trace,pallet-assets=trace"]
+  args = ["--log=xcm=trace,pallet-assets=trace,pallet-uniques=trace"]
 
 [[parachains]]
 id = 3000
@@ -54,13 +54,13 @@ chain = "stout-local"
   name = "stout-collator01"
   command = "./target/release/trappist-node"
   ws_port = 9930
-  args = ["--log=xcm=trace,pallet-assets=trace"]
+  args = ["--log=xcm=trace,pallet-assets=trace,pallet-uniques=trace"]
 
   [[parachains.collators]]
   name = "stout-collator02"
   command = "./target/release/trappist-node"
   ws_port = 9931
-  args = ["--log=xcm=trace,pallet-assets=trace"]
+  args = ["--log=xcm=trace,pallet-assets=trace,pallet-uniques=trace"]
 
 [types.Header]
 number = "u64"


### PR DESCRIPTION
With cross-chain NFT transfers enabled on asset hub: https://github.com/paritytech/polkadot-sdk/pull/2796 a good demonstration of XCM NFT transfers is enabling it between stout and asset hub.

I will probably look into adding this to Trappist as well, however, that will require some changes to the `asset-registry` pallet so that will be a separate PR.