### PR TITLE
fix: renamed statemine in zombienet toml files

### DIFF
--- a/zombienet/stout_rococo.toml
+++ b/zombienet/stout_rococo.toml
@@ -30,16 +30,16 @@ default_command = "./bin/polkadot"
 id = 1000
 add_to_genesis = true
 cumulus_based = true
-chain = "statemine-local"
+chain = "asset-hub-rococo-local"
 
   [[parachains.collators]]
-  name = "statemine-collator01"
+  name = "asset-hub-rococo-collator01"
   command = "./bin/polkadot-parachain"
   ws_port = 9910
   args = ["--log=xcm=trace,pallet-assets=trace"]
 
   [[parachains.collators]]
-  name = "statemine-collator02"
+  name = "asset-hub-rococo-collator02"
   command = "./bin/polkadot-parachain"
   ws_port = 9911
   args = ["--log=xcm=trace,pallet-assets=trace"]

--- a/zombienet/trappist_rococo.toml
+++ b/zombienet/trappist_rococo.toml
@@ -30,16 +30,16 @@ default_command = "./bin/polkadot"
 id = 1000
 add_to_genesis = true
 cumulus_based = true
-chain = "statemine-local"
+chain = "asset-hub-rococo-local"
 
   [[parachains.collators]]
-  name = "statemine-collator01"
+  name = "asset-hub-rococo-collator01"
   command = "./bin/polkadot-parachain"
   ws_port = 9910
   args = ["--log=xcm=trace,pallet-assets=trace"]
 
   [[parachains.collators]]
-  name = "statemine-collator02"
+  name = "asset-hub-rococo-collator02"
   command = "./bin/polkadot-parachain"
   ws_port = 9911
   args = ["--log=xcm=trace,pallet-assets=trace"]


### PR DESCRIPTION
### Issue 
Same issue as the one found [here](https://github.com/paritytech/asset-transfer-api/pull/356).

I get the error
```
Error: Input("Error opening spec file `statemine-local`: No such file or directory (os error 2)")
```
when I try to run `zombienet` with the `trappist_rococo`/ `stout_rococo` toml files.

### Binaries versions
I use : 
- `polkadot` and `polkadot-parachain` binaries built in version `polkadot 1.6.0`
- `zombienet-macos` version `1.3.90`

### Solution
I renamed `statemine` to `asset-hub-rococo` in the toml files of zombienet and then it runs as expected.