### PR TITLE
Prepare Trappist v1.3.1 release

### DIFF
--- a/runtime/stout/src/lib.rs
+++ b/runtime/stout/src/lib.rs
@@ -137,7 +137,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("stout-rococo"),
 	impl_name: create_runtime_str!("stout-rococo"),
 	authoring_version: 1,
-	spec_version: 13000,
+	spec_version: 13100,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,

--- a/runtime/trappist/Cargo.toml
+++ b/runtime/trappist/Cargo.toml
@@ -215,6 +215,7 @@ runtime-benchmarks = [
 	"polkadot-runtime-parachains/runtime-benchmarks"
 ]
 try-runtime = [
+	"hex-literal",
 	"frame-try-runtime/try-runtime",
 	"frame-executive/try-runtime",
 	"frame-system/try-runtime",

--- a/runtime/trappist/src/lib.rs
+++ b/runtime/trappist/src/lib.rs
@@ -165,7 +165,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("trappist-rococo"),
 	impl_name: create_runtime_str!("trappist-rococo"),
 	authoring_version: 1,
-	spec_version: 13000,
+	spec_version: 13100,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,


### PR DESCRIPTION
This release is for testing EVM bridged assets through Snowbridge 