### PR TITLE
add WithUniqueTopic wrapper in Trappist and Stout xcm routers

### DIFF
--- a/runtime/stout/src/xcm_config.rs
+++ b/runtime/stout/src/xcm_config.rs
@@ -49,7 +49,7 @@ use xcm_builder::{
 	EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, FungiblesAdapter, IsConcrete,
 	MintLocation, NativeAsset, NoChecking, ParentAsSuperuser, ParentIsPreset, RelayChainAsNative,
 	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
-	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
+	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, UsingComponents, WithUniqueTopic
 };
 use xcm_executor::XcmExecutor;
 
@@ -299,12 +299,12 @@ pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, R
 
 /// The means for routing XCM messages which are not for local execution into the right message
 /// queues.
-pub type XcmRouter = (
+pub type XcmRouter = WithUniqueTopic<(
 	// Two routers - use UMP to communicate with the relay chain:
 	cumulus_primitives_utility::ParentAsUmp<ParachainSystem, PolkadotXcm, ()>,
 	// ..and XCMP to communicate with the sibling chains.
 	XcmpQueue,
-);
+)>;
 
 impl pallet_xcm::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;

--- a/runtime/trappist/src/xcm_config.rs
+++ b/runtime/trappist/src/xcm_config.rs
@@ -38,7 +38,7 @@ use xcm_builder::{
 	MintLocation, NativeAsset, NoChecking, ParentAsSuperuser, ParentIsPreset, RelayChainAsNative,
 	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
 	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId,
-	UsingComponents, WeightInfoBounds, WithComputedOrigin,
+	UsingComponents, WeightInfoBounds, WithComputedOrigin, WithUniqueTopic
 };
 use xcm_executor::{traits::JustTry, XcmExecutor};
 
@@ -371,12 +371,12 @@ pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, R
 
 /// The means for routing XCM messages which are not for local execution into the right message
 /// queues.
-pub type XcmRouter = (
+pub type XcmRouter = WithUniqueTopic<(
 	// Two routers - use UMP to communicate with the relay chain:
 	cumulus_primitives_utility::ParentAsUmp<ParachainSystem, PolkadotXcm, ()>,
 	// ..and XCMP to communicate with the sibling chains.
 	XcmpQueue,
-);
+)>;
 
 impl pallet_xcm::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;


### PR DESCRIPTION
This PR adds the `WithUniqueTopic` wrapper, introduced in https://github.com/paritytech/polkadot/pull/7234, to the Trappist and Stout XCM routers to ensure that all XCMs are appended with a `SetTopic` instruction.

This will allow for easier tracking of XCM, especially in the case of multi-hop messages where the message hash differs on each leg.

More detailed explanation: https://substrate.stackexchange.com/questions/1893/is-there-an-id-for-xcm-message/1906#1906